### PR TITLE
Fix agentA release stream and improve testing scripts

### DIFF
--- a/src/AI_APP/agentA/src/agentA.py
+++ b/src/AI_APP/agentA/src/agentA.py
@@ -134,11 +134,16 @@ class AgentA:
                         if int(now) % 10 == 0:
                             logger.info("Waiting for reset signal from V_Brain...")
                         continue
-                        
+                    
+                    # Reconnect to stream again, go back to detection loop
+                    self.stream_manager.connect()
+                    self.awaiting_reset = False
                     logger.info(f"Reset received (reason={message_obj.reason}), resuming detection...") # type: ignore
                 
-                if now - self.last_message_time > self.config.decision_timeout:
+                elif self.awaiting_reset and (now - self.last_message_time) > self.config.decision_timeout:
                     logger.info("Reset timeout exceeded while waiting for decision, resuming detection anyway...")
+                    self.stream_manager.connect()
+                    self.awaiting_reset = False
                 
                 self._process_detection()
 
@@ -218,7 +223,6 @@ class AgentA:
                 except Exception as e:
                     logger.exception(f"Error drawing boxes: {e}")
 
-
                 # Record metrics
                 self.trucks_detected.inc(num_boxes)
                 self.detection_confidence.observe(max_conf)
@@ -228,11 +232,15 @@ class AgentA:
                     topic=self.config.kafka_topic_produce,
                     data=message.to_dict(),
                     headers={"truck_id": truck_id}
-                )
+                )       
                 
                 # Force delivery callbacks to process immediately so we see the log
                 self.kafka_producer.flush(timeout=1)
                 self.last_message_time = time.time()
+
+                # Disconnect from stream to free up resources while waiting for reset
+                self.stream_manager.release()
+
                 logger.info(f"Truck detected! truck_id={truck_id}, confidence={max_conf:.2f}, num_detections={num_boxes}.")
 
                 # Truck detected and message sent; return to the main loop

--- a/src/AI_APP/agentA/tests/agentA_unitTest.py
+++ b/src/AI_APP/agentA/tests/agentA_unitTest.py
@@ -35,6 +35,7 @@ def mock_dependencies():
         "object_detector": MagicMock(),
         "stream_manager": MagicMock(),
         "kafka_producer": MagicMock(),
+        "kafka_consumer": MagicMock(),
         "image_storage": MagicMock(),
         "drawer": MagicMock()
     }
@@ -68,6 +69,7 @@ class TestAgentAInit:
         assert agent.yolo is mock_dependencies["object_detector"]
         assert agent.stream_manager is mock_dependencies["stream_manager"]
         assert agent.kafka_producer is mock_dependencies["kafka_producer"]
+        assert agent.kafka_consumer is mock_dependencies["kafka_consumer"]
         assert agent.image_storage is mock_dependencies["image_storage"]
         assert agent.drawer is mock_dependencies["drawer"]
 
@@ -200,6 +202,7 @@ class TestProcessDetection:
         
         # Should not raise exception
         agent_a._process_detection()
+        agent_a.stream_manager.release.assert_not_called()
 
 # =============================================================================
 # Tests for start() loop
@@ -225,11 +228,11 @@ class TestLoop:
         agent_a.running = True
         agent_a.awaiting_reset = True
         agent_a.last_message_time = time.time() # Within timeout
+        agent_a.stream_manager.connect.reset_mock()
         
         # Simulate receiving reset message
         mock_msg = MagicMock()
         mock_msg.reason = "test"
-        agent_a.kafka_consumer = MagicMock()
         agent_a.kafka_consumer.consume_typed_message.return_value = ("topic", mock_msg, "TRK1")
         
         with patch.object(agent_a, '_process_detection') as mock_process:
@@ -237,6 +240,8 @@ class TestLoop:
             agent_a.start()
             
             agent_a.kafka_consumer.consume_typed_message.assert_called_once()
+            agent_a.stream_manager.connect.assert_called_once()
+            assert agent_a.awaiting_reset is False
             mock_process.assert_called_once()
 
     def test_start_handles_timeout(self, agent_a):
@@ -244,16 +249,16 @@ class TestLoop:
         agent_a.running = True
         agent_a.awaiting_reset = True
         agent_a.last_message_time = time.time() - 100 # Past timeout
-        
-        mock_consumer = MagicMock()
-        agent_a.kafka_consumer = mock_consumer
+        agent_a.stream_manager.connect.reset_mock()
         
         with patch.object(agent_a, '_process_detection') as mock_process:
             mock_process.side_effect = lambda: setattr(agent_a, 'running', False)
             agent_a.start()
             
             # Shouldn't consume if timed out
-            mock_consumer.consume_typed_message.assert_not_called()
+            agent_a.kafka_consumer.consume_typed_message.assert_not_called()
+            agent_a.stream_manager.connect.assert_called_once()
+            assert agent_a.awaiting_reset is False
             mock_process.assert_called_once()
 
 # =============================================================================

--- a/src/AI_APP/shared/src/image_storage.py
+++ b/src/AI_APP/shared/src/image_storage.py
@@ -31,7 +31,6 @@ class ImageStorage:
         logger.info("Initializing MinIO client...")
         self.client = Minio(**configs)
         self.bucket_name = bucket_name
-        self._bucket_verified = False
     
     def upload_memory_image(self, img_array: Optional[np.ndarray], object_name: str, image_type: str = "other") -> Optional[str]:
         """
@@ -109,9 +108,6 @@ class ImageStorage:
 
     def _ensure_bucket(self) -> bool:
         """Checks if bucket exists, creates it if not. Returns True if bucket is ready."""
-        if self._bucket_verified:
-            return True
-        
         try:
             if not self.client.bucket_exists(self.bucket_name):
                 try:
@@ -125,7 +121,6 @@ class ImageStorage:
                     
             # Always ensure lifecycle policies are up to date
             self._set_lifecycle_policies()
-            self._bucket_verified = True
             
             return True
         

--- a/src/AI_APP/shared/src/stream_manager.py
+++ b/src/AI_APP/shared/src/stream_manager.py
@@ -22,9 +22,8 @@ class StreamManager:
         self.running = False
         self.thread = None
 
-        # REPLACED threading.Lock with a blocking Queue.
-        # maxsize=1 ensures we only ever hold the single newest frame in memory.
-        self.frame_queue = queue.Queue(maxsize=1) 
+        # Queue for frames
+        self.frame_queue = queue.Queue() 
 
         logger.info(f"Initialized for: {url}")
 
@@ -110,7 +109,7 @@ class StreamManager:
                 continue
 
             try:
-                ret, frame = self.cap.read()
+                ret, frame = self.cap.read() # type: ignore
 
                 if ret:
                     self._handle_read_success(frame)

--- a/src/V_APP/api_gateway/src/api_gateway.py
+++ b/src/V_APP/api_gateway/src/api_gateway.py
@@ -138,7 +138,7 @@ class APIGateway:
                     payload["truck_id"] = truck_id
 
                 # 1. Filter out internal logic messages (SKIPPED decisions)
-                if payload.get("decision") == "SKIPPED" or payload.get("decision") == "MANUAL_REVIEW":
+                if payload.get("decision") == "SKIPPED":
                     continue
                 
                 # 2. Determine the target gate for broadcasting:

--- a/src/V_APP/api_gateway/src/api_gateway.py
+++ b/src/V_APP/api_gateway/src/api_gateway.py
@@ -138,7 +138,7 @@ class APIGateway:
                     payload["truck_id"] = truck_id
 
                 # 1. Filter out internal logic messages (SKIPPED decisions)
-                if payload.get("decision") == "SKIPPED":
+                if payload.get("decision") == "SKIPPED" or payload.get("decision") == "MANUAL_REVIEW":
                     continue
                 
                 # 2. Determine the target gate for broadcasting:

--- a/src/V_APP/decision_engine/src/decision_engine.py
+++ b/src/V_APP/decision_engine/src/decision_engine.py
@@ -133,7 +133,7 @@ class DecisionEngine(BaseDecisionEngine):
             if matched_plate == self.last_truck_detected.get(gate_id):
                 self.logger.info(f"Gate {gate_id} | Same truck detected: {matched_plate}, publishing SKIPPED")
                 self._publish_decision(
-                    gate_id, truck_id, license_plate, lp_msg, hz_msg, un_number, kemler_code,
+                    gate_id, truck_id, matched_plate, lp_msg, hz_msg, un_number, kemler_code,
                     decision=DecisionStatus.SKIPPED.value,
                     reason="Same truck detected again shortly after initial detection",
                     start_time=start_time,
@@ -142,7 +142,7 @@ class DecisionEngine(BaseDecisionEngine):
 
             alerts = [f"Truck {matched_plate} accepted."]
             self._publish_decision(
-                gate_id, truck_id, license_plate, lp_msg, hz_msg, un_number, kemler_code,
+                gate_id, truck_id, matched_plate, lp_msg, hz_msg, un_number, kemler_code,
                 decision=DecisionStatus.ACCEPTED.value,
                 reason="License plate matched with appointment",
                 start_time=start_time,

--- a/src/V_APP/infraction_engine/src/infraction_engine.py
+++ b/src/V_APP/infraction_engine/src/infraction_engine.py
@@ -6,6 +6,7 @@ multiple gates.
 """
 
 import time
+from typing import Tuple
 from prometheus_client import Counter # type: ignore
 from shared.src.kafka_protocol import (
     HazardPlateResultsMessage, KafkaMessageProto,
@@ -73,7 +74,7 @@ class InfractionEngine(BaseDecisionEngine):
             return
 
         # Truck IS hazardous — check if it has a matching appointment at THIS gate.
-        has_appointment = self._has_matching_appointment(gate_id, license_plate)
+        has_appointment, license_plate = self._has_matching_appointment("1", license_plate)
         infraction = True
         
         if has_appointment:
@@ -92,10 +93,10 @@ class InfractionEngine(BaseDecisionEngine):
         """Determine if the truck carries hazardous goods."""
         return bool(raw_un and raw_un != "N/A") or bool(raw_kemler and raw_kemler != "N/A")
 
-    def _has_matching_appointment(self, gate_id: str, license_plate: str) -> bool:
+    def _has_matching_appointment(self, gate_id: str, license_plate: str) -> Tuple[bool, str]:
         """Check whether the license plate matches any scheduled appointment for this gate."""
         if license_plate == "N/A":
-            return False
+            return False, license_plate
 
         try:
             # Temporarily override gate_id for the query
@@ -105,18 +106,21 @@ class InfractionEngine(BaseDecisionEngine):
             self.database_client.gate_id = original_gid
         except Exception:
             self.logger.exception(f"Error querying appointments for gate {gate_id}")
-            return False
+            return False, license_plate
 
         if appointments is not None and self.database_client.is_api_unavailable(appointments.get("message", "")):
-            return False
+            return False, license_plate
 
         if appointments is None or appointments.get("found") is False:
-            return False
+            return False, license_plate
 
         candidate_plates = [appt["license_plate"] for appt in appointments.get("candidates", [])]
         matched_plate = self.plate_matcher.match_plate(license_plate, candidate_plates)
+        
+        if matched_plate is None:
+            return False, license_plate
 
-        return matched_plate is not None
+        return matched_plate is not None, matched_plate
 
     def _publish_infraction(
         self,

--- a/src/V_APP/test_scripts/send_payload.py
+++ b/src/V_APP/test_scripts/send_payload.py
@@ -1,0 +1,111 @@
+"""
+Usage:
+    python send_payload.py decision
+    python send_payload.py infraction
+"""
+
+import argparse
+import base64
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../"))
+
+from shared.src.kafka_protocol import (
+    KafkaTopicFactory,
+    DecisionResultsMessage,
+    InfractionDecisionMessage,
+)
+from shared.src.kafka_wrapper import KafkaProducerWrapper
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+BROKER   = "10.255.32.70:9092"
+GATE_ID  = "1"
+TRUCK_ID = "truck-001"
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+LP_IMAGE   = "lp.png"
+HZ_IMAGE   = "hz.png"
+
+
+# ---------------------------------------------------------------------------
+# Image encoding
+# ---------------------------------------------------------------------------
+
+def to_data_uri(filename: str) -> str:
+    path = os.path.join(SCRIPT_DIR, filename)
+    with open(path, "rb") as f:
+        encoded = base64.b64encode(f.read()).decode("utf-8")
+    ext = os.path.splitext(filename)[1].lstrip(".")
+    mime = "image/jpeg" if ext in ("jpg", "jpeg") else f"image/{ext}"
+    return f"data:{mime};base64,{encoded}"
+
+
+# ---------------------------------------------------------------------------
+# Payloads
+# ---------------------------------------------------------------------------
+
+def make_decision_message(lp_url: str, hz_url: str) -> DecisionResultsMessage:
+    return DecisionResultsMessage(
+        license_plate="87AX60",
+        license_crop_url=lp_url,
+        un="1831: Sulfuric acid, fuming with less than 30% free sulfur trioxide",
+        kemler="X886: Highly corrosive substance, toxic, which reacts dangerously with water (water not to be used except by approval of experts)",
+        hazard_crop_url=hz_url,
+        alerts=[],
+        route="GATE_1 → ZONE_A",
+        decision="ACCEPTED",
+        decision_reason="All checks passed, truck is authorized.",
+        decision_source="automated",
+    )
+
+
+def make_infraction_message(lp_url: str, hz_url: str) -> InfractionDecisionMessage:
+    return InfractionDecisionMessage(
+        license_plate="87AX60",
+        license_crop_url=lp_url,
+        un="1831: Sulfuric acid, fuming with less than 30% free sulfur trioxide",
+        kemler="X886: Highly corrosive substance, toxic, which reacts dangerously with water (water not to be used except by approval of experts)",
+        hazard_crop_url=hz_url,
+        infraction=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("type", choices=["decision", "infraction"])
+    args = parser.parse_args()
+
+    lp_url = to_data_uri(LP_IMAGE)
+    hz_url = to_data_uri(HZ_IMAGE)
+
+    if args.type == "decision":
+        topic   = KafkaTopicFactory.agent_decision("1")
+        message = make_decision_message(lp_url, hz_url)
+    else:
+        topic   = KafkaTopicFactory.infraction_decision("2")
+        message = make_infraction_message(lp_url, hz_url)
+
+    headers = {"truck_id": TRUCK_ID}
+
+    print(f"Broker : {BROKER}")
+    print(f"Topic  : {topic}")
+    print(f"Truck  : {TRUCK_ID}")
+
+    with KafkaProducerWrapper(BROKER) as producer:
+        producer.produce(topic=topic, data=message.to_dict(), headers=headers)
+        producer.flush()
+
+    print("Message delivered.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/V_APP/v_brain/src/v_brain.py
+++ b/src/V_APP/v_brain/src/v_brain.py
@@ -330,14 +330,27 @@ class VBrain:
 
 
 
+    #def _reset_agent_a(self, gate_id: str, reason: str = "unknown") -> None:
+    #    """Publish reset-agentA to V_Broker → V_Gateway → IA_Gateway → AgentA."""
+    #    msg = KafkaMessageProto.reset_agent_a(reason=reason)
+    #    self.kafka_producer.produce(
+    #        topic=KafkaTopicFactory.reset_agent_a(gate_id),
+    #        data=msg.to_dict(),
+    #    )
+    #    logger.info(f"Reset AgentA published (reason={reason}) for gate {gate_id}")
+    
+    # Reset agentA with 5 second delay
     def _reset_agent_a(self, gate_id: str, reason: str = "unknown") -> None:
-        """Publish reset-agentA to V_Broker → V_Gateway → IA_Gateway → AgentA."""
-        msg = KafkaMessageProto.reset_agent_a(reason=reason)
-        self.kafka_producer.produce(
-            topic=KafkaTopicFactory.reset_agent_a(gate_id),
-            data=msg.to_dict(),
-        )
-        logger.info(f"Reset AgentA published (reason={reason}) for gate {gate_id}")
+        def _delayed():
+            time.sleep(7)
+            msg = KafkaMessageProto.reset_agent_a(reason=reason)
+            self.kafka_producer.produce(
+                topic=KafkaTopicFactory.reset_agent_a(gate_id),
+                data=msg.to_dict(),
+            )
+            logger.info(f"Reset AgentA published (reason={reason}) for gate {gate_id}")
+
+        threading.Thread(target=_delayed, daemon=True).start()
 
     
     def _get_scale_status(self, gate_id: str) -> bool:

--- a/src/V_APP/v_brain/src/v_brain.py
+++ b/src/V_APP/v_brain/src/v_brain.py
@@ -341,6 +341,7 @@ class VBrain:
     
     # Reset agentA with 5 second delay
     def _reset_agent_a(self, gate_id: str, reason: str = "unknown") -> None:
+        logger.info(f"Scheduling reset of AgentA for gate {gate_id} in 7 seconds (reason={reason})")
         def _delayed():
             time.sleep(7)
             msg = KafkaMessageProto.reset_agent_a(reason=reason)


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes across multiple components, focusing on better resource management, improved test coverage, and enhanced logic for decision and infraction handling. The most notable changes include proper stream connection management in `agentA`, a fix to license plate matching logic, and a new test script for sending Kafka payloads.

**Resource management and detection loop improvements (`agentA`):**

* Ensured the stream is reconnected when a reset signal is received or a reset timeout occurs, and released (disconnected) after a detection to free up resources while waiting for the next reset. This prevents resource leaks and ensures the detection loop behaves as expected. [[1]](diffhunk://#diff-19d332fcdd0314d5d539bf6a4ee56d3ffd0d8ab5eb476b26d1c0afa11c98782cR138-R146) [[2]](diffhunk://#diff-19d332fcdd0314d5d539bf6a4ee56d3ffd0d8ab5eb476b26d1c0afa11c98782cR240-R243)
* Updated tests to verify new stream connection/disconnection logic, including assertions for the state of `stream_manager` and `awaiting_reset`. [[1]](diffhunk://#diff-154d6010b932694ed49a57fcf2cc740e74cfc2d542c6443aefe771bf35edae8bR231-R261) [[2]](diffhunk://#diff-154d6010b932694ed49a57fcf2cc740e74cfc2d542c6443aefe771bf35edae8bR72) [[3]](diffhunk://#diff-154d6010b932694ed49a57fcf2cc740e74cfc2d542c6443aefe771bf35edae8bR205)
* Added `kafka_consumer` to the mocked dependencies for more complete test coverage.

**Decision and infraction logic fixes:**

* Fixed a bug in the decision engine where the wrong license plate variable was used when publishing a decision, ensuring the matched plate is always used. [[1]](diffhunk://#diff-f6f09a2d7a6b6460c895f470eeee37f32c53ce916d7bddb52eee6e550364fd90L136-R136) [[2]](diffhunk://#diff-f6f09a2d7a6b6460c895f470eeee37f32c53ce916d7bddb52eee6e550364fd90L145-R145)
* Modified the infraction engine's appointment check to return both the match status and the matched plate, updating all relevant logic and usages accordingly. [[1]](diffhunk://#diff-8531cf9c3437e961035896f0ff717a6d19b3a6f1c365123e9f270456b5b5fb78L76-R77) [[2]](diffhunk://#diff-8531cf9c3437e961035896f0ff717a6d19b3a6f1c365123e9f270456b5b5fb78L95-R99) [[3]](diffhunk://#diff-8531cf9c3437e961035896f0ff717a6d19b3a6f1c365123e9f270456b5b5fb78L108-R123)

**Testing and utilities:**

* Added a new test script, `send_payload.py`, that can send sample decision or infraction messages to Kafka for integration testing.

**Other improvements:**

* Removed unnecessary state from `image_storage.py` by eliminating the `_bucket_verified` flag, ensuring bucket lifecycle policies are always set and simplifying the logic. [[1]](diffhunk://#diff-fd50a14ff2b4586e7e38d1dc1827881d88b373f49dc43c7b50b5ecbe6ef366ddL34) [[2]](diffhunk://#diff-fd50a14ff2b4586e7e38d1dc1827881d88b373f49dc43c7b50b5ecbe6ef366ddL112-L114) [[3]](diffhunk://#diff-fd50a14ff2b4586e7e38d1dc1827881d88b373f49dc43c7b50b5ecbe6ef366ddL128)
* Changed the frame queue in `stream_manager.py` to be unbounded, allowing for more flexible frame handling.
* Added a delayed reset mechanism in `v_brain.py` to schedule AgentA resets with a 7-second delay, improving reliability and logging.

These changes collectively improve system reliability, resource management, and testability across the application.