### PR TITLE
Update appointment states and enhance MongoDB logging

### DIFF
--- a/src/V_APP/Data_Module/application/queries/manager_statistics_queries.py
+++ b/src/V_APP/Data_Module/application/queries/manager_statistics_queries.py
@@ -252,7 +252,7 @@ def get_dashboard_summary(target_date: Optional[str] = None) -> Dict[str, Any]:
             "vehiclesPerHour": vehicles_per_hour,
         }
     except Exception as e:
-        logger.error("get_dashboard_summary failed: %s", e)
+        logger.exception("get_dashboard_summary failed: %s", e)
         return {
             "trucksInPort": 0,
             "trucksInTransit": 0,
@@ -327,7 +327,7 @@ def _transport_stats_from_pg(start, end) -> List[Dict[str, Any]]:
             })
         return result
     except Exception as e:
-        logger.error("get_transport_stats failed: %s", e)
+        logger.exception("get_transport_stats failed: %s", e)
         return []
     finally:
         db.close()
@@ -435,7 +435,7 @@ def compute_company_metrics_snapshot(db_session: Session, period_days: int = 30)
             count += 1
         return count
     except Exception as e:
-        logger.error("compute_company_metrics_snapshot failed: %s", e)
+        logger.exception("compute_company_metrics_snapshot failed: %s", e)
         return 0
 
 
@@ -513,7 +513,7 @@ def get_volume_data(
             for r in rows
         ]
     except Exception as e:
-        logger.error("get_volume_data failed: %s", e)
+        logger.exception("get_volume_data failed: %s", e)
         return []
     finally:
         db.close()
@@ -553,7 +553,7 @@ def get_alerts_breakdown(
             for r in rows
         ]
     except Exception as e:
-        logger.error("get_alerts_breakdown failed: %s", e)
+        logger.exception("get_alerts_breakdown failed: %s", e)
         return []
     finally:
         db.close()
@@ -673,7 +673,7 @@ def get_decision_analytics(
             "avgDetectionToDecisionMs": 0,
         }
     except Exception as e:
-        logger.error("get_decision_analytics failed: %s", e)
+        logger.exception("get_decision_analytics failed: %s", e)
         return {
             "totalDecisions": 0,
             "accepted": 0,

--- a/src/V_APP/Data_Module/application/queries/manager_statistics_queries.py
+++ b/src/V_APP/Data_Module/application/queries/manager_statistics_queries.py
@@ -362,6 +362,10 @@ def get_transport_stats(
                     })
             if result:
                 return result
+        logger.warning(
+            "transport_stats: company_metrics_collection is empty — falling back to PG; "
+            "check statistics_aggregator is running",
+        )
     except Exception as e:
         logger.warning("company_metrics_collection unavailable: %s — falling back to PG", e)
 
@@ -461,6 +465,11 @@ def get_volume_data(
         return mongo_result
 
     # ── 2) PostgreSQL fallback ───────────────────────────────────────────────
+    logger.warning(
+        "volume_data: no Mongo docs for interval=%s [%s, %s] — falling back to PG; "
+        "check statistics_aggregator is running",
+        interval, start.date(), end.date(),
+    )
     db: Session = SessionLocal()
     try:
         if interval == "day":

--- a/src/V_APP/Data_Module/application/schemas.py
+++ b/src/V_APP/Data_Module/application/schemas.py
@@ -408,7 +408,7 @@ class VisitBase(BaseModel):
     shift_date: date
     entry_time: Optional[datetime] = None
     out_time: Optional[datetime] = None
-    state: DeliveryStatusEnum = DeliveryStatusEnum.unloading
+    state: DeliveryStatusEnum = DeliveryStatusEnum.not_started
 
 
 class VisitCreate(VisitBase):

--- a/src/V_APP/Data_Module/infrastructure/persistence/visit_repository.py
+++ b/src/V_APP/Data_Module/infrastructure/persistence/visit_repository.py
@@ -62,7 +62,7 @@ class SqlAlchemyVisitRepository(IVisitRepository):
             shift_type=shift_type,
             shift_date=shift_date,
             entry_time=entry_time or datetime.now(timezone.utc).replace(tzinfo=None),
-            state="unloading",
+            state="not_started",
         )
         self._session.add(visit)
         self._session.flush()

--- a/src/V_APP/Data_Module/main.py
+++ b/src/V_APP/Data_Module/main.py
@@ -15,6 +15,7 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.instrumentation.pymongo import PymongoInstrumentor
 from opentelemetry.sdk.resources import Resource
 
 from routes.arrivals import router as arrivals_router
@@ -253,7 +254,8 @@ else:
     _otel_status["enabled"] = False
     _otel_status["reachable"] = False
 
-# Instrument FastAPI
+# Instrument FastAPI and pymongo
+PymongoInstrumentor().instrument()
 FastAPIInstrumentor.instrument_app(app)
 
 # Prometheus metrics at /metrics

--- a/src/V_APP/Data_Module/requirements.txt
+++ b/src/V_APP/Data_Module/requirements.txt
@@ -23,6 +23,7 @@ opentelemetry-api
 opentelemetry-sdk
 opentelemetry-exporter-otlp-proto-grpc
 opentelemetry-instrumentation-fastapi
+opentelemetry-instrumentation-pymongo
 
 # --- Security ---
 bcrypt==4.0.1

--- a/src/V_APP/Data_Module/routes/decisions.py
+++ b/src/V_APP/Data_Module/routes/decisions.py
@@ -270,7 +270,7 @@ def manual_review(
 
     When approved:
     - Updates Appointment.status to 'in_process' (confirmed arrival)
-    - Creates Visit with state='unloading' if gate_id provided
+    - Creates Visit with state='not_started' if gate_id provided
 
     When rejected:
     - Updates Appointment.status to 'canceled'
@@ -359,7 +359,7 @@ def manual_review(
             )
             if visit_result:
                 result["visit_created"] = True
-                result["visit_state"] = "unloading"
+                result["visit_state"] = visit_result["state"]
         except Exception as e:
             result["visit_error"] = str(e)
 


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the codebase, primarily focusing on better observability for MongoDB fallbacks, updating the default state for new `Visit` records, and enhancing OpenTelemetry instrumentation. The most significant changes include improved logging when MongoDB data is unavailable, a shift in the default `Visit` state from `unloading` to `not_started`, and the addition of OpenTelemetry instrumentation for pymongo to improve tracing.

**Observability and Logging Improvements:**

* Added warning logs in `get_transport_stats` and `get_volume_data` to notify when MongoDB collections are empty or unavailable, indicating a fallback to PostgreSQL and suggesting to check if the `statistics_aggregator` is running. [[1]](diffhunk://#diff-5f41c8e5c9e2c4965a20909a4882ae77ab4771fcd72bc20bcd079441f6319baaR365-R368) [[2]](diffhunk://#diff-5f41c8e5c9e2c4965a20909a4882ae77ab4771fcd72bc20bcd079441f6319baaR468-R472)

**Data Model and Business Logic Updates:**

* Changed the default `state` for new `Visit` records from `unloading` to `not_started` in both the data schema (`VisitBase`) and repository logic, and updated related documentation and responses to reflect this new default. [[1]](diffhunk://#diff-be97e6e0ed8c56279b5713bef3f43534121345498c90873902fc0f5e6a1d4f05L411-R411) [[2]](diffhunk://#diff-8fef458960105bdc12668571e6d79d325bf8eb821da0860e951be42213efb5f0L65-R65) [[3]](diffhunk://#diff-2985be144a4d23490087a94485304959f7c4c3b5c1842d2100a7b1847be33f84L273-R273) [[4]](diffhunk://#diff-2985be144a4d23490087a94485304959f7c4c3b5c1842d2100a7b1847be33f84L362-R362)

**Observability/Instrumentation Enhancements:**

* Added the `opentelemetry-instrumentation-pymongo` package and enabled pymongo instrumentation in the application to improve tracing and observability of MongoDB operations. [[1]](diffhunk://#diff-9c97e2c0ab2bbb744d45ec8422b388ae360d24f9c0a8613707b5affc8ea04b50R26) [[2]](diffhunk://#diff-db85e963888640beb24f30922db912cc5ac9eca86d93cafc3419053ff60c6575R18) [[3]](diffhunk://#diff-db85e963888640beb24f30922db912cc5ac9eca86d93cafc3419053ff60c6575L256-R258)…ngoDB fallbacks