### PR TITLE
Fix driver access control checks

### DIFF
--- a/src/V_APP/api_gateway/src/routers/drivers.py
+++ b/src/V_APP/api_gateway/src/routers/drivers.py
@@ -3,7 +3,7 @@ from typing import Annotated, Optional
 import os
 
 import jwt as _jwt
-from fastapi import APIRouter, Query, Path, Depends, Body
+from fastapi import APIRouter, Query, Path, Depends, Body, HTTPException, status
 from pydantic import BaseModel
 from loguru import logger
 
@@ -35,6 +35,40 @@ def _dm_driver_jwt(drivers_license: str) -> str:
 def _dm_auth(drivers_license: str) -> dict[str, str]:
     """Return an Authorization header dict for DM /me/* calls."""
     return {"Authorization": f"Bearer {_dm_driver_jwt(drivers_license)}"}
+
+
+def _normalize_license(drivers_license: str | None) -> str:
+    return (drivers_license or "").strip().upper()
+
+
+def _ensure_driver_self_or_manager(drivers_license: str, current_user: TokenPayload) -> None:
+    """Allow managers to access any driver, but drivers only their own data."""
+    if "manager" in current_user.roles:
+        return
+
+    if "driver" in current_user.roles and _normalize_license(current_user.sub) == _normalize_license(drivers_license):
+        return
+
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="Drivers can only access their own data",
+    )
+
+
+async def _get_owned_appointment(appointment_id: int, current_user: TokenPayload) -> dict:
+    """Fetch an appointment and ensure the authenticated driver owns it."""
+    appointment = await internal_client.get(f"/arrivals/{appointment_id}")
+    if not isinstance(appointment, dict):
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Invalid appointment response")
+
+    driver_license = appointment.get("driver_license")
+    if _normalize_license(driver_license) != _normalize_license(current_user.sub):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Drivers can only update their own appointments",
+        )
+
+    return appointment
 
 
 # ---------------------------------
@@ -129,11 +163,12 @@ async def get_my_history(
 @router.get("/drivers/{drivers_license}")
 async def get_driver(
     drivers_license: Annotated[str, Path(description="Driver's License")],
-    _user: Annotated[TokenPayload, Depends(require_role("driver", "manager"))],
+    current_user: Annotated[TokenPayload, Depends(require_role("driver", "manager"))],
 ):
     """
     Proxy to GET /api/v1/drivers/{drivers_license}
     """
+    _ensure_driver_self_or_manager(drivers_license, current_user)
     return await internal_client.get(f"/drivers/{drivers_license}")
 
 
@@ -143,12 +178,13 @@ async def get_driver(
 @router.get("/drivers/{drivers_license}/arrivals")
 async def get_arrivals_for_driver(
     drivers_license: Annotated[str, Path(description="Driver's License")],
-    _user: Annotated[TokenPayload, Depends(require_role("driver", "manager"))],
+    current_user: Annotated[TokenPayload, Depends(require_role("driver", "manager"))],
     limit: Annotated[int, Query(ge=1, le=200)] = 50,
 ):
     """
     Proxy to GET /api/v1/drivers/{drivers_license}/arrivals
     """
+    _ensure_driver_self_or_manager(drivers_license, current_user)
     path = f"/drivers/{drivers_license}/arrivals"
     params = {"limit": limit}
     return await internal_client.get(path, params=params)
@@ -172,6 +208,7 @@ async def update_driver_appointment_status(
     Update appointment status and broadcast status_changed via WebSocket.
     Allows drivers to update their own appointments.
     """
+    await _get_owned_appointment(appointment_id, current_user)
     result = await internal_client.patch(
         f"/arrivals/{appointment_id}/status",
         json=update_data.model_dump(exclude_none=True)
@@ -221,6 +258,7 @@ async def update_driver_visit_state(
     Update visit state (e.g. 'unloading', 'completed') and broadcast via WebSocket.
     Allows drivers to signal unloading start / completion at the dock.
     """
+    appointment = await _get_owned_appointment(appointment_id, current_user)
     result = await internal_client.patch(
         f"/arrivals/{appointment_id}/visit",
         json=update_data.model_dump(exclude_none=True)
@@ -234,7 +272,7 @@ async def update_driver_visit_state(
     gate_in_id = result.get("appointment_id") if isinstance(result, dict) else None
     # visit response has appointment_id; fetch gate from result if available
     try:
-        appt_result = await internal_client.get(f"/arrivals/{appointment_id}")
+        appt_result = appointment
         gate_in_id = appt_result.get("gate_in_id") if isinstance(appt_result, dict) else None
         driver_license = appt_result.get("driver_license") if isinstance(appt_result, dict) else None
     except Exception:

--- a/src/V_APP/api_gateway/src/routers/drivers.py
+++ b/src/V_APP/api_gateway/src/routers/drivers.py
@@ -269,15 +269,8 @@ async def update_driver_visit_state(
         "new_status": update_data.state,
     }
 
-    gate_in_id = result.get("appointment_id") if isinstance(result, dict) else None
-    # visit response has appointment_id; fetch gate from result if available
-    try:
-        appt_result = appointment
-        gate_in_id = appt_result.get("gate_in_id") if isinstance(appt_result, dict) else None
-        driver_license = appt_result.get("driver_license") if isinstance(appt_result, dict) else None
-    except Exception:
-        gate_in_id = None
-        driver_license = None
+    gate_in_id = appointment.get("gate_in_id") if isinstance(appointment, dict) else None
+    driver_license = appointment.get("driver_license") if isinstance(appointment, dict) else None
 
     if gate_in_id:
         try:

--- a/src/V_APP/api_gateway/tests/api_gateway_unit_test.py
+++ b/src/V_APP/api_gateway/tests/api_gateway_unit_test.py
@@ -135,6 +135,42 @@ class TestGatewayAppAndAuth:
         assert "manager" in response.json()["detail"]
         data_get.assert_not_awaited()
 
+    def test_driver_cannot_read_another_driver_profile(self, client):
+        with patch("clients.internal_api_client.get", new_callable=AsyncMock) as data_get:
+            response = client.get("/api/drivers/DL-999", headers=auth_headers("driver-token"))
+
+        assert response.status_code == 403
+        assert "own data" in response.json()["detail"]
+        data_get.assert_not_awaited()
+
+    def test_driver_can_read_own_profile_case_insensitively(self, client):
+        expected = {"drivers_license": "DL-123", "name": "Driver"}
+        with patch("clients.internal_api_client.get", new_callable=AsyncMock) as data_get:
+            data_get.return_value = expected
+            response = client.get("/api/drivers/DL-123", headers=auth_headers("driver-token"))
+
+        assert response.status_code == 200
+        assert response.json() == expected
+        data_get.assert_awaited_once_with("/drivers/DL-123")
+
+    def test_manager_can_read_any_driver_profile(self, client):
+        expected = {"drivers_license": "DL-999", "name": "Other Driver"}
+        with patch("clients.internal_api_client.get", new_callable=AsyncMock) as data_get:
+            data_get.return_value = expected
+            response = client.get("/api/drivers/DL-999", headers=auth_headers("manager-token"))
+
+        assert response.status_code == 200
+        assert response.json() == expected
+        data_get.assert_awaited_once_with("/drivers/DL-999")
+
+    def test_driver_cannot_read_another_driver_arrivals(self, client):
+        with patch("clients.internal_api_client.get", new_callable=AsyncMock) as data_get:
+            response = client.get("/api/drivers/DL-999/arrivals", headers=auth_headers("driver-token"))
+
+        assert response.status_code == 403
+        assert "own data" in response.json()["detail"]
+        data_get.assert_not_awaited()
+
 
 class TestProxyRoutes:
     def test_arrivals_proxy_translates_query_aliases_and_filters(self, client):
@@ -351,6 +387,51 @@ class TestManualReviewAndWebSockets:
             "/arrivals/55/status",
             json={"status": "completed", "notes": "left gate"},
         )
+        ws_manager.broadcast.assert_awaited_once()
+        ws_manager.broadcast_to_driver.assert_awaited_once_with(
+            "DL-123",
+            {"message_type": "status_changed", "appointment_id": 55, "new_status": "completed"},
+        )
+
+    def test_driver_status_update_requires_owned_appointment(self, client, ws_manager):
+        with (
+            patch("clients.internal_api_client.get", new_callable=AsyncMock) as data_get,
+            patch("clients.internal_api_client.patch", new_callable=AsyncMock) as data_patch,
+        ):
+            data_get.return_value = {"id": 55, "driver_license": "DL-999", "gate_in_id": 1}
+            response = client.patch(
+                "/api/drivers/appointments/55/status",
+                json={"status": "completed"},
+                headers=auth_headers("driver-token"),
+            )
+
+        assert response.status_code == 403
+        assert "own appointments" in response.json()["detail"]
+        data_get.assert_awaited_once_with("/arrivals/55")
+        data_patch.assert_not_awaited()
+        ws_manager.broadcast.assert_not_awaited()
+        ws_manager.broadcast_to_driver.assert_not_awaited()
+
+    def test_driver_status_update_allows_owned_appointment(self, client, ws_manager):
+        appointment = {"id": 55, "driver_license": "DL-123", "gate_in_id": 1}
+        result = {"id": 55, "driver_license": "DL-123", "gate_in_id": 1, "status": "completed"}
+
+        with (
+            patch("clients.internal_api_client.get", new_callable=AsyncMock) as data_get,
+            patch("clients.internal_api_client.patch", new_callable=AsyncMock) as data_patch,
+        ):
+            data_get.return_value = appointment
+            data_patch.return_value = result
+            response = client.patch(
+                "/api/drivers/appointments/55/status",
+                json={"status": "completed"},
+                headers=auth_headers("driver-token"),
+            )
+
+        assert response.status_code == 200
+        assert response.json() == result
+        data_get.assert_awaited_once_with("/arrivals/55")
+        data_patch.assert_awaited_once_with("/arrivals/55/status", json={"status": "completed"})
         ws_manager.broadcast.assert_awaited_once()
         ws_manager.broadcast_to_driver.assert_awaited_once_with(
             "DL-123",

--- a/src/V_APP/api_gateway/tests/api_gateway_unit_test.py
+++ b/src/V_APP/api_gateway/tests/api_gateway_unit_test.py
@@ -171,6 +171,26 @@ class TestGatewayAppAndAuth:
         assert "own data" in response.json()["detail"]
         data_get.assert_not_awaited()
 
+    def test_driver_can_read_own_arrivals(self, client):
+        expected = [{"id": 10, "driver_license": "DL-123"}]
+        with patch("clients.internal_api_client.get", new_callable=AsyncMock) as data_get:
+            data_get.return_value = expected
+            response = client.get("/api/drivers/DL-123/arrivals", headers=auth_headers("driver-token"))
+
+        assert response.status_code == 200
+        assert response.json() == expected
+        data_get.assert_awaited_once_with("/drivers/DL-123/arrivals", params={"limit": 50})
+
+    def test_manager_can_read_any_driver_arrivals(self, client):
+        expected = [{"id": 20, "driver_license": "DL-999"}]
+        with patch("clients.internal_api_client.get", new_callable=AsyncMock) as data_get:
+            data_get.return_value = expected
+            response = client.get("/api/drivers/DL-999/arrivals", headers=auth_headers("manager-token"))
+
+        assert response.status_code == 200
+        assert response.json() == expected
+        data_get.assert_awaited_once_with("/drivers/DL-999/arrivals", params={"limit": 50})
+
 
 class TestProxyRoutes:
     def test_arrivals_proxy_translates_query_aliases_and_filters(self, client):
@@ -436,6 +456,54 @@ class TestManualReviewAndWebSockets:
         ws_manager.broadcast_to_driver.assert_awaited_once_with(
             "DL-123",
             {"message_type": "status_changed", "appointment_id": 55, "new_status": "completed"},
+        )
+
+    def test_driver_visit_update_denied_for_non_owned_appointment(self, client, ws_manager):
+        with (
+            patch("clients.internal_api_client.get", new_callable=AsyncMock) as data_get,
+            patch("clients.internal_api_client.patch", new_callable=AsyncMock) as data_patch,
+        ):
+            data_get.return_value = {"id": 55, "driver_license": "DL-999", "gate_in_id": 1}
+            response = client.patch(
+                "/api/drivers/appointments/55/visit",
+                json={"state": "unloading"},
+                headers=auth_headers("driver-token"),
+            )
+
+        assert response.status_code == 403
+        assert "own appointments" in response.json()["detail"]
+        data_get.assert_awaited_once_with("/arrivals/55")
+        data_patch.assert_not_awaited()
+        ws_manager.broadcast.assert_not_awaited()
+        ws_manager.broadcast_to_driver.assert_not_awaited()
+
+    def test_driver_visit_update_allowed_for_owned_appointment(self, client, ws_manager):
+        appointment = {"id": 55, "driver_license": "DL-123", "gate_in_id": 1}
+        result = {"id": 55, "driver_license": "DL-123", "gate_in_id": 1, "visit_state": "unloading"}
+
+        with (
+            patch("clients.internal_api_client.get", new_callable=AsyncMock) as data_get,
+            patch("clients.internal_api_client.patch", new_callable=AsyncMock) as data_patch,
+        ):
+            data_get.return_value = appointment
+            data_patch.return_value = result
+            response = client.patch(
+                "/api/drivers/appointments/55/visit",
+                json={"state": "unloading"},
+                headers=auth_headers("driver-token"),
+            )
+
+        assert response.status_code == 200
+        assert response.json() == result
+        data_get.assert_awaited_once_with("/arrivals/55")
+        data_patch.assert_awaited_once_with("/arrivals/55/visit", json={"state": "unloading"})
+        ws_manager.broadcast.assert_awaited_once_with(
+            "1",
+            {"message_type": "status_changed", "appointment_id": 55, "new_status": "unloading"},
+        )
+        ws_manager.broadcast_to_driver.assert_awaited_once_with(
+            "DL-123",
+            {"message_type": "status_changed", "appointment_id": 55, "new_status": "unloading"},
         )
 
 


### PR DESCRIPTION
## Summary

Fixes a Broken Access Control issue in driver-facing API Gateway endpoints.

Drivers can no longer access or modify data belonging to another driver by changing path parameters such as `drivers_license` or `appointment_id`. The API Gateway now enforces ownership using the authenticated JWT identity.

## Changes

- Added driver ownership checks for:
  - `GET /api/drivers/{drivers_license}`
  - `GET /api/drivers/{drivers_license}/arrivals`
- Preserved manager access to any driver profile/arrivals.
- Added appointment ownership validation before driver status/visit updates.
- Added unit tests covering:
  - driver denied when accessing another driver’s data
  - driver allowed when accessing own data
  - manager allowed to access any driver
  - driver denied when updating another driver’s appointment
  - driver allowed when updating own appointment

## Validation

```bash
PYTHONPATH=src:src/V_APP/api_gateway/src uv run pytest -q src/V_APP/api_gateway/tests/api_gateway_unit_test.py