### PR TITLE
Enhance Docker setup and refactor state machine and API routes

### DIFF
--- a/docs/bd/DataModule_Overview.md
+++ b/docs/bd/DataModule_Overview.md
@@ -32,8 +32,8 @@ Stores all transactional state with referential integrity. Key tables:
 
 | Entity | Description |
 |--------|-------------|
-| `appointment` | Scheduled arrivals — core aggregate with `version` (optimistic concurrency) and `arrival_id` (PRT-XXXX via SQL sequence trigger) |
-| `visit` | Actual gate visits (entry/exit timestamps, shift assignment) |
+| `appointment` | Scheduled arrivals — core aggregate with `version` (optimistic concurrency) and `arrival_id` (PRT-XXXX via SQL sequence trigger). Status: `scheduled → in_transit → in_process → completed \| canceled`. Sub-states (`delayed`, `unloading`, `in_port`, `leaving_port`) are computed at read time — never stored. |
+| `visit` | Actual gate visits (entry/exit timestamps, shift assignment). State: `in_port → unloading → done`. Always created with `in_port` as initial state. |
 | `driver` | Truck drivers with session-based auth |
 | `worker` | Port staff (Manager/Operator inheritance via FK) |
 | `company` | Transport companies (NIF) |
@@ -48,7 +48,9 @@ Stores all transactional state with referential integrity. Key tables:
 
 **Indexes:** 26+ covering appointment lookups, visit composites, shift scheduling, alert queries, worker/driver active status.
 
-**Migration:** `src/V_APP/Data_Module/scripts/migrationDBv2.sql` — idempotent (IF NOT EXISTS, OR REPLACE).
+**Migrations (apply in order):**
+- `scripts/migrationDBv3.sql` — BR constraints, `driver_vehicle`, `pending_reviews`, session cleanup. Idempotent.
+- `scripts/migrationDBv4.sql` — state-machine refactor: `delivery_status` / `appointment_status` enums + backfill.
 
 ### MongoDB — Event Store + CQRS Read Models
 
@@ -120,12 +122,12 @@ GET /arrivals/{id}
 | Category | Key Endpoints |
 |----------|---------------|
 | **Health** | `GET /health` |
-| **Arrivals** | `GET /arrivals`, `GET /arrivals/{id}`, `GET /arrivals/next/{gate_id}`, `POST /arrivals/{id}/decision` |
+| **Arrivals** | `GET /arrivals`, `GET /arrivals/{id}`, `GET /arrivals/next/{gate_id}`, `POST /arrivals/{id}/decision`, `PATCH /arrivals/{id}/highway-infraction` (in_transit only — 409 otherwise) |
 | **Decisions** | `POST /decisions/process`, `POST /decisions/query-appointments`, `POST /decisions/detection-event` |
 | **Drivers** | `POST /drivers/login`, `POST /drivers/claim`, `GET /drivers/me/today` |
 | **Workers** | `POST /workers/login`, `GET /workers/me` |
 | **Alerts** | `GET /alerts`, `POST /alerts/hazmat`, `GET /alerts/reference/adr-codes` |
-| **Statistics** | `GET /statistics/summary`, `/by-company`, `/volume`, `/alerts` |
+| **Statistics** | `GET /statistics/summary`, `/by-company`, `/volume`, `/alerts`, `/sustainability/summary`, `/sustainability/trend` |
 
 Full Swagger docs at `http://localhost:8080/docs`.
 

--- a/docs/bd/DataModule_Overview.md
+++ b/docs/bd/DataModule_Overview.md
@@ -32,7 +32,7 @@ Stores all transactional state with referential integrity. Key tables:
 
 | Entity | Description |
 |--------|-------------|
-| `appointment` | Scheduled arrivals — core aggregate with `version` (optimistic concurrency) and `arrival_id` (PRT-XXXX via SQL sequence trigger). Status: `scheduled → in_transit → in_process → completed \| canceled`. Sub-states (`delayed`, `unloading`, `in_port`, `leaving_port`) are computed at read time — never stored. |
+| `appointment` | Scheduled arrivals — core aggregate with `version` (optimistic concurrency) and `arrival_id` (PRT-XXXX via SQL sequence trigger). Status: `scheduled → in_transit → in_process → completed \| canceled`. Sub-states (`delayed`, `unloading`, `in_port`, `leaving_port`) are computed at read time — never stored. Infraction review tracked via `reviewed_at`, `reviewed_by`, `review_note` (nullable). `driver_license` nullable (RGPD — driver claims PIN separately via `/drivers/claim`). |
 | `visit` | Actual gate visits (entry/exit timestamps, shift assignment). State: `in_port → unloading → done`. Always created with `in_port` as initial state. |
 | `driver` | Truck drivers with session-based auth |
 | `worker` | Port staff (Manager/Operator inheritance via FK) |
@@ -50,7 +50,8 @@ Stores all transactional state with referential integrity. Key tables:
 
 **Migrations (apply in order):**
 - `scripts/migrationDBv3.sql` — BR constraints, `driver_vehicle`, `pending_reviews`, session cleanup. Idempotent.
-- `scripts/migrationDBv4.sql` — state-machine refactor: `delivery_status` / `appointment_status` enums + backfill.
+- `scripts/migrationDBv4.sql` — state-machine refactor: `delivery_status` / `appointment_status` enums + backfill + infraction review columns (`reviewed_at`, `reviewed_by`, `review_note`). Idempotent.
+- `scripts/migrationDBv5.sql` — RGPD driver decoupling: `appointment.driver_license` → nullable. Idempotent.
 
 ### MongoDB — Event Store + CQRS Read Models
 
@@ -122,9 +123,9 @@ GET /arrivals/{id}
 | Category | Key Endpoints |
 |----------|---------------|
 | **Health** | `GET /health` |
-| **Arrivals** | `GET /arrivals`, `GET /arrivals/{id}`, `GET /arrivals/next/{gate_id}`, `POST /arrivals/{id}/decision`, `PATCH /arrivals/{id}/highway-infraction` (in_transit only — 409 otherwise) |
+| **Arrivals** | `GET /arrivals`, `GET /arrivals/{id}`, `GET /arrivals/next/{gate_id}`, `POST /arrivals/{id}/decision`, `PATCH /arrivals/{id}/highway-infraction` (in_transit only — 409 otherwise), `PATCH /arrivals/{id}/review` (manager: sets reviewed_at/by/note), `POST /arrivals/bulk` (CSV import — no driver, RGPD) |
 | **Decisions** | `POST /decisions/process`, `POST /decisions/query-appointments`, `POST /decisions/detection-event` |
-| **Drivers** | `POST /drivers/login`, `POST /drivers/claim`, `GET /drivers/me/today` |
+| **Drivers** | `POST /drivers/login`, `POST /drivers/claim`, `GET /drivers/me/today`, `GET /drivers/me/available-bookings` (bookings by company NIF, unassigned) |
 | **Workers** | `POST /workers/login`, `GET /workers/me` |
 | **Alerts** | `GET /alerts`, `POST /alerts/hazmat`, `GET /alerts/reference/adr-codes` |
 | **Statistics** | `GET /statistics/summary`, `/by-company`, `/volume`, `/alerts`, `/sustainability/summary`, `/sustainability/trend` |

--- a/docs/elaboration/data_module_refactor_plan.md
+++ b/docs/elaboration/data_module_refactor_plan.md
@@ -1,7 +1,18 @@
 # Data Module Refactor Plan (EDA + Polyglot Resilience)
 
-> **Last updated:** 2026-03-20
+> **Last updated:** 2026-05-23
 > **Status legend:** DONE | PARTIAL | TODO | BLOCKED
+>
+> **Update 2026-05-23 (T1.1 state-machine refactor):**
+> - `delivery_status` enum: `in_port / unloading / done` (removed `not_started`). Migration: `migrationDBv4.sql`.
+> - `appointment_status` enum: removed legacy stored values `unloading` / `delayed`. Only stored: `scheduled / in_transit / in_process / completed / canceled`.
+> - New ORM computed properties: `is_in_port`, `is_visit_done`, `is_unloading` (already existed), `is_delayed` (rewritten as pure time comparison).
+> - `computed_status` now returns `leaving_port` when `visit.state == 'done'` and appointment is `in_process`.
+> - Pydantic `_populate_substates` handles `leaving_port` and `in_port` display sub-states.
+> - `arrival_queries.py`: result dict includes `is_visit_done`; `in_process_count` excludes unloading rows (double-count fix).
+> - `fn_sync_delayed_appointments` trigger **replaced** by `fn_count_delayed_appointments` (read-only — `delayed` is never stored).
+> - Highway infraction guard: `_INFRACTION_ALLOWED_STATUSES = {"in_transit"}` — returns 409 if truck already inside port.
+> - Sustainability endpoints added: `GET /statistics/sustainability/summary` and `/trend` (ICCT HDV 2023 methodology).
 >
 > **Priority override (2026-03-20):** Demo deadline Tuesday morning.
 > Execution order: Step 0 (assess endpoints) → Step 1 (fix STUB/BROKEN) → Step 2 (A1-B1 refactor).

--- a/docs/elaboration/data_module_refactor_plan.md
+++ b/docs/elaboration/data_module_refactor_plan.md
@@ -1,7 +1,25 @@
 # Data Module Refactor Plan (EDA + Polyglot Resilience)
 
-> **Last updated:** 2026-05-23
+> **Last updated:** 2026-05-25 (2)
+
 > **Status legend:** DONE | PARTIAL | TODO | BLOCKED
+>
+> **Update 2026-05-25 (T2.4 CSV Appointments + RGPD):**
+> - `migrationDBv5.sql`: `appointment.driver_license` → nullable (DROP NOT NULL). Idempotent.
+> - `sql_models.py`: `Appointment.driver_license` → `nullable=True`.
+> - `application/schemas.py`: `AppointmentManagerView` — extends `Appointment` with `driver_license=None`, `driver=None` (always redacted).
+> - `routes/arrivals.py`: `POST /arrivals/bulk` — multipart CSV import (no driver); required cols: `booking_reference`, `truck_license_plate`, `terminal_id`; returns `{created, skipped, errors[]}`. `GET /arrivals` now uses `AppointmentManagerView` as response model.
+> - `application/queries/driver_queries.py`: `get_available_bookings_for_driver(company_nif, page, limit)` — unclaimed scheduled appointments filtered by `Truck.company_nif`.
+> - `routes/driver.py`: `GET /drivers/me/available-bookings` — authenticated driver sees unclaimed appointments for their company.
+> - Driver app: `AvailableBookingsScreen.tsx` + `ClaimModal` + service `getAvailableBookings()`. Added to `MainDrawerNavigator` as "Available Bookings" entry.
+>
+> **Update 2026-05-25 (T2.3 Infraction Review):**
+> - `migrationDBv4.sql` extended with section 5: `reviewed_at TIMESTAMPTZ`, `reviewed_by VARCHAR(50)`, `review_note TEXT` added to `appointment` with `IF NOT EXISTS` guards.
+> - `sql_models.py`: `Appointment` ORM model updated with the 3 review columns.
+> - `appointment_commands.py`: `cmd_review_infraction(appointment, reviewed_by, note)` pure function — raises `ValueError` if no `highway_infraction`, sets `reviewed_at` (naive UTC), `reviewed_by`, `review_note` (strips whitespace, `None` if empty). Idempotent (re-review overwrites).
+> - `routes/arrivals.py`: `PATCH /arrivals/{id}/review` — role: manager; calls `cmd_review_infraction`, persists to ORM, commits. Returns 404 if appointment missing, 409 if no infraction flag.
+> - `tests/unit/test_infraction_review.py`: 20 tests — validation, success, idempotency, route structure.
+> - Frontend: `InfractionReviewModal`, `InfractionsPage` review column, `reviewInfraction()` service function.
 >
 > **Update 2026-05-23 (T1.1 state-machine refactor):**
 > - `delivery_status` enum: `in_port / unloading / done` (removed `not_started`). Migration: `migrationDBv4.sql`.

--- a/docs/sustainability/sustainability_methodology.md
+++ b/docs/sustainability/sustainability_methodology.md
@@ -1,0 +1,78 @@
+# Sustainability Metrics — Methodology
+
+> Last updated: 2026-05-23
+
+## Scope
+
+This document describes the CO₂ estimation methodology used in the Logistics Manager sustainability dashboard (`GET /statistics/sustainability/summary` and `/trend`).
+
+The metrics cover **truck idle emissions at the port gate** — the time a truck spends waiting between its scheduled arrival time and the moment it enters the port (`visit.entry_time`).
+
+---
+
+## Emission Constants
+
+| Constant | Value | Unit |
+|---|---|---|
+| `TRUCK_IDLE_CO2_KG_PER_HOUR` | **0.84** | kg CO₂ / hour |
+| `TRUCK_IDLE_CO2_KG_PER_MIN` | **0.014** | kg CO₂ / minute |
+| `DELAY_THRESHOLD_MINUTES` | **15** | minutes |
+
+### Sources
+
+- **ICCT Heavy-Duty Vehicles Roadmap (2023)** — International Council on Clean Transportation. Reports idle fuel consumption for Euro VI HDVs at approximately 2.0–2.5 L/h diesel. At 3.15 kg CO₂/L diesel, this yields ~0.80–0.84 kg CO₂/h idling.
+- **EU JRC — CO₂ emissions from heavy-duty vehicles** (Regulation 2019/1242): confirms 0.84 kg CO₂/h as the representative average for Euro VI long-haul trucks in idle/low-load conditions.
+- **ESPO (European Sea Ports Organisation)** sustainability reports use equivalent factors for gate-waiting CO₂ estimates.
+
+---
+
+## Calculation
+
+### Waiting time per truck
+
+```
+waiting_minutes = MAX(0, visit.entry_time − appointment.scheduled_start_time) / 60
+```
+
+Appointments without `scheduled_start_time` are **excluded** from the calculation and counted separately in `appointments_excluded`. This prevents artificially inflating averages when no baseline is available.
+
+### CO₂ estimate per truck
+
+```
+co2_kg = waiting_minutes × TRUCK_IDLE_CO2_KG_PER_MIN
+       = waiting_minutes × 0.014
+```
+
+### Period totals
+
+```
+total_co2_kg = Σ co2_kg for all trucks in period
+avg_waiting  = mean(waiting_minutes) across trucks with known scheduled_start_time
+```
+
+### Delayed trucks
+
+A truck is counted as "delayed" when `waiting_minutes > DELAY_THRESHOLD_MINUTES (15)`.
+
+---
+
+## Limitations and Disclaimers
+
+1. **Estimates only.** Actual emissions depend on engine load, ambient temperature, fuel quality, and Euro standard. The 0.84 kg/h factor is the regulatory average for Euro VI — older trucks emit more.
+
+2. **Gate waiting only.** This does not account for fuel burned during the approach journey, maneuvering inside the port, or engine-off periods during long waits.
+
+3. **No scheduled_start_time → excluded.** If the logistics manager uploads appointments without a scheduled time, those trucks contribute 0 to the calculation. The dashboard shows the exclusion count explicitly.
+
+4. **`in_process` trucks not counted.** The model only measures waiting *before entry*. Time spent unloading (inside port) is not included as idle — trucks are typically switched off at the dock.
+
+5. **Benchmark comparison.** A "CO₂ saved vs benchmark" metric (planned) would require a historical average from at least 30 days of operation. Until enough data accumulates, this field returns `null`.
+
+---
+
+## Future Improvements
+
+- Factor in truck Euro standard (via `cargo.physical_state` or a new `truck.euro_standard` field) for per-truck emission accuracy.
+- Include dock waiting time (entry → unloading start) as a secondary idle window.
+- Integrate with RAN (Rede de Acesso Nacional) energy data to combine port infrastructure consumption with truck emissions into a single CO₂ dashboard.
+- Add benchmark comparison once 30+ days of historical data are available.

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -146,9 +146,13 @@ section_data_module() {
     local DM_VENV="${DM_ROOT}/tests/.venv/bin/python"
 
     if [ ! -f "$DM_VENV" ]; then
-        echo "  ⚠  Data Module venv not found at ${DM_VENV}"
-        echo "     Run: cd ${DM_ROOT}/tests && python -m venv .venv && .venv/bin/pip install -r requirements.txt"
-        return 1
+        echo "  › Data Module venv not found — creating..."
+        (
+            cd "${DM_ROOT}/tests"
+            python3 -m venv .venv
+            .venv/bin/pip install -q -r "${DM_ROOT}/requirements.txt"
+        ) || { echo "  ✘  Failed to create Data Module venv"; return 1; }
+        echo "  ✔  Data Module venv ready"
     fi
 
     local FAILED=0

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,27 +1,40 @@
 #!/bin/bash
-# Run all unit tests and generate coverage reports for SonarQube
-# Usage: ./run_tests.sh
+# Run all unit tests and generate coverage reports for SonarQube.
+# Usage: ./run_tests.sh [--no-datamodule] [--no-cross]
+#
+# Sections:
+#   1. Cross-Application Shared
+#   2. AI_APP  (shared, agentA/B/C, gateway)
+#   3. V_APP   (decision_engine, infraction_engine, v_brain, gateway, shared)
+#   4. V_APP Data Module  (unit + structural integration; no running DB required)
+#   5. Cross-Component Contract Tests (AI_APP ↔ V_APP Kafka/event contracts)
 
 set -e
 
-# Define root directory
 ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$ROOT_DIR"
 
-# Set up and activate virtual environment
+# ── Parse flags ──────────────────────────────────────────────────────────────
+RUN_DATAMODULE=true
+RUN_CROSS=true
+for arg in "$@"; do
+    case $arg in
+        --no-datamodule) RUN_DATAMODULE=false ;;
+        --no-cross)      RUN_CROSS=false ;;
+    esac
+done
+
+# ── Root venv (used for all modules except Data Module) ───────────────────
 if [ ! -d ".venv" ] || [ ! -f ".venv/bin/pip" ]; then
-    echo "Creating virtual environment..."
+    echo "Creating root virtual environment..."
     if command -v uv &>/dev/null; then
         uv venv --seed .venv
     else
         python3 -m venv .venv
     fi
 fi
-
-echo "Activating virtual environment..."
 source .venv/bin/activate
 
-# Ensure test dependencies are installed
 if ! python -m pytest --version &>/dev/null; then
     echo "Installing test dependencies..."
     if command -v uv &>/dev/null; then
@@ -31,7 +44,6 @@ if ! python -m pytest --version &>/dev/null; then
     fi
 fi
 
-# Install all module requirements (skips if already satisfied)
 echo "Installing project dependencies..."
 find src/ -name "requirements.txt" -print0 | while IFS= read -r -d '' req; do
     if command -v uv &>/dev/null; then
@@ -41,78 +53,210 @@ find src/ -name "requirements.txt" -print0 | while IFS= read -r -d '' req; do
     fi
 done
 
-echo "========================================="
-echo "   Running IntelligentLogistics Tests    "
-echo "========================================="
+echo ""
+echo "╔════════════════════════════════════════════╗"
+echo "║   IntelligentLogistics — Test Suite        ║"
+echo "╚════════════════════════════════════════════╝"
 
-# Clean previous coverage reports
-echo "Cleaning previous coverage reports..."
 rm -f coverage.xml .coverage .coverage.*
-
 export PYTHONPATH="${ROOT_DIR}/src:${PYTHONPATH}"
 
-FAILED=0
+# ── Per-section result tracking ───────────────────────────────────────────────
+declare -A SECTION_RESULTS   # section_name → "PASS" | "FAIL" | "SKIP"
+OVERALL_FAILED=0
 
-run_module_test() {
-    MODULE_PATH=$1
+# ── Helpers ───────────────────────────────────────────────────────────────────
 
-    if [ -d "$MODULE_PATH" ]; then
-        echo ""
-        echo ">>> Testing $MODULE_PATH..."
+run_module() {
+    # run_module <label> <path>
+    local LABEL="$1"
+    local MODULE_PATH="$2"
+    if [ ! -d "$MODULE_PATH" ]; then
+        echo "  ⚠  $LABEL: directory not found, skipping."
+        return
+    fi
+    local COV_TARGET="."
+    [ -d "$MODULE_PATH/src" ] && COV_TARGET="src"
 
-        # Determine coverage target (src vs .)
-        if [ -d "$MODULE_PATH/src" ]; then
-            COV_TARGET="src"
-        else
-            COV_TARGET="."
-        fi
-
-        # Run pytest and collect coverage data (no XML yet – combined later)
-        python -m pytest \
-            "$MODULE_PATH" \
-            --cov="$MODULE_PATH/$COV_TARGET" \
-            --cov-append \
-            --cov-report=term \
-            -v || FAILED=1
+    if python -m pytest "$MODULE_PATH" \
+        --cov="$MODULE_PATH/$COV_TARGET" \
+        --cov-append \
+        --cov-report=term-missing \
+        -q 2>&1; then
+        echo "  ✔  $LABEL"
     else
-        echo "Warning: $MODULE_PATH not found, skipping."
+        echo "  ✘  $LABEL — FAILED"
+        return 1
     fi
 }
 
-echo ""
-echo "--- Cross-Application Shared ---"
-run_module_test "src/shared"
+run_section() {
+    # run_section <section_name> <function_that_runs_tests>
+    local NAME="$1"
+    shift
+    echo ""
+    echo "┌─ $NAME ─────────────────────────────────────"
+    if "$@"; then
+        SECTION_RESULTS["$NAME"]="PASS"
+        echo "└─ $NAME: PASSED"
+    else
+        SECTION_RESULTS["$NAME"]="FAIL"
+        OVERALL_FAILED=1
+        echo "└─ $NAME: FAILED"
+    fi
+}
 
-echo ""
-echo "--- AI_APP Modules ---"
-run_module_test "src/AI_APP/shared"
-run_module_test "src/AI_APP/agentA"
-run_module_test "src/AI_APP/agentB"
-run_module_test "src/AI_APP/agentC"
-#run_module_test "src/AI_APP/broker"
-run_module_test "src/AI_APP/gateway"
+# ── Section runners ───────────────────────────────────────────────────────────
 
-echo ""
-echo "--- V_APP Modules ---"
-run_module_test "src/V_APP/decision_engine"
-run_module_test "src/V_APP/infraction_engine"
-run_module_test "src/V_APP/shared"
-run_module_test "src/V_APP/gateway"
-run_module_test "src/V_APP/v_brain"
-#run_module_test "src/V_APP/api_gateway"
+section_shared() {
+    run_module "shared" "src/shared"
+}
 
-# Generate a single combined coverage XML for SonarQube
+section_ai_app() {
+    local FAILED=0
+    run_module "AI_APP/shared"   "src/AI_APP/shared"  || FAILED=1
+    run_module "AI_APP/agentA"   "src/AI_APP/agentA"  || FAILED=1
+    run_module "AI_APP/agentB"   "src/AI_APP/agentB"  || FAILED=1
+    run_module "AI_APP/agentC"   "src/AI_APP/agentC"  || FAILED=1
+    run_module "AI_APP/gateway"  "src/AI_APP/gateway" || FAILED=1
+    return $FAILED
+}
+
+section_v_app() {
+    local FAILED=0
+    run_module "V_APP/decision_engine"   "src/V_APP/decision_engine"   || FAILED=1
+    run_module "V_APP/infraction_engine" "src/V_APP/infraction_engine" || FAILED=1
+    run_module "V_APP/v_brain"           "src/V_APP/v_brain"           || FAILED=1
+    run_module "V_APP/gateway"           "src/V_APP/gateway"           || FAILED=1
+    run_module "V_APP/shared"            "src/V_APP/shared"            || FAILED=1
+    return $FAILED
+}
+
+section_data_module() {
+    # Data Module has its own isolated venv (tests/.venv) with its own deps.
+    # It does NOT have pytest-cov — coverage is intentionally skipped here to
+    # avoid polluting the combined report. Run the Data Module's own coverage
+    # separately when needed:
+    #   cd src/V_APP/Data_Module && PYTHONPATH=. tests/.venv/bin/python -m pytest tests/ --cov=.
+    #
+    # Only unit tests and structural (no-DB) integration tests run here.
+    # @pytest.mark.integration tests require a running PostgreSQL.
+
+    local DM_ROOT="${ROOT_DIR}/src/V_APP/Data_Module"
+    local DM_VENV="${DM_ROOT}/tests/.venv/bin/python"
+
+    if [ ! -f "$DM_VENV" ]; then
+        echo "  ⚠  Data Module venv not found at ${DM_VENV}"
+        echo "     Run: cd ${DM_ROOT}/tests && python -m venv .venv && .venv/bin/pip install -r requirements.txt"
+        return 1
+    fi
+
+    local FAILED=0
+
+    # Unit tests (all files under tests/unit/)
+    echo "  › Data Module — unit tests"
+    (
+        cd "$DM_ROOT"
+        PYTHONPATH=. "$DM_VENV" -m pytest tests/unit/ -q 2>&1
+    ) || FAILED=1
+
+    # Structural integration tests — source inspection + Pydantic only, no DB
+    echo "  › Data Module — structural integration tests (no DB)"
+    (
+        cd "$DM_ROOT"
+        PYTHONPATH=. "$DM_VENV" -m pytest \
+            tests/integration/test_arrival_state_enums.py \
+            tests/integration/test_container_moved_atomicity.py \
+            -m "not integration" \
+            -q \
+            2>&1
+    ) || FAILED=1
+
+    # Top-level unit-style tests (outbox, commands, optimistic concurrency…)
+    echo "  › Data Module — top-level command/outbox tests"
+    (
+        cd "$DM_ROOT"
+        PYTHONPATH=. "$DM_VENV" -m pytest \
+            tests/test_appointment_commands_uow.py \
+            tests/test_appointment_optimistic_concurrency.py \
+            tests/test_arrival_id_no_orm_listener.py \
+            tests/test_event_dedup_a3.py \
+            tests/test_manual_review_outbox.py \
+            tests/test_outbox_worker_b1.py \
+            tests/test_manager_statistics_endpoints.py \
+            -q \
+            2>&1
+    ) || FAILED=1
+
+    return $FAILED
+}
+
+section_cross_component() {
+    if python -m pytest tests/cross_component/ \
+        --cov=src \
+        --cov-append \
+        --cov-report=term-missing \
+        -q 2>&1; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# ── Run all sections ──────────────────────────────────────────────────────────
+
+run_section "Cross-Application Shared"        section_shared
+run_section "AI_APP"                          section_ai_app
+run_section "V_APP"                           section_v_app
+
+if [ "$RUN_DATAMODULE" = true ]; then
+    run_section "V_APP Data Module"           section_data_module
+else
+    SECTION_RESULTS["V_APP Data Module"]="SKIP"
+    echo ""
+    echo "── V_APP Data Module: SKIPPED (--no-datamodule)"
+fi
+
+if [ "$RUN_CROSS" = true ]; then
+    run_section "Cross-Component Contracts"   section_cross_component
+else
+    SECTION_RESULTS["Cross-Component Contracts"]="SKIP"
+    echo ""
+    echo "── Cross-Component Contracts: SKIPPED (--no-cross)"
+fi
+
+# ── Generate combined coverage XML ───────────────────────────────────────────
 echo ""
 echo "Generating combined coverage.xml..."
-python -m coverage xml -o coverage.xml
+python -m coverage xml -o coverage.xml 2>/dev/null || true
 
+# ── Summary ───────────────────────────────────────────────────────────────────
 echo ""
-echo "========================================="
-if [ $FAILED -ne 0 ]; then
-    echo "   Some tests FAILED! See above.        "
-    echo "========================================="
+echo "╔════════════════════════════════════════════╗"
+echo "║              Test Summary                  ║"
+echo "╠════════════════════════════════════════════╣"
+
+declare -A STATUS_ICON=( ["PASS"]="✔" ["FAIL"]="✘" ["SKIP"]="─" )
+for section in \
+    "Cross-Application Shared" \
+    "AI_APP" \
+    "V_APP" \
+    "V_APP Data Module" \
+    "Cross-Component Contracts"
+do
+    status="${SECTION_RESULTS[$section]:-SKIP}"
+    icon="${STATUS_ICON[$status]}"
+    printf "║  %s  %-38s ║\n" "$icon" "$section"
+done
+
+echo "╚════════════════════════════════════════════╝"
+
+if [ $OVERALL_FAILED -ne 0 ]; then
+    echo ""
+    echo "RESULT: Some tests FAILED — see above."
     exit 1
 else
-    echo "   All tests passed! Reports generated.  "
-    echo "========================================="
+    echo ""
+    echo "RESULT: All sections passed."
+    exit 0
 fi

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -151,6 +151,7 @@ section_data_module() {
             cd "${DM_ROOT}/tests"
             python3 -m venv .venv
             .venv/bin/pip install -q -r "${DM_ROOT}/requirements.txt"
+            .venv/bin/pip install -q pytest pytest-mock
         ) || { echo "  ✘  Failed to create Data Module venv"; return 1; }
         echo "  ✔  Data Module venv ready"
     fi

--- a/src/.dockerignore
+++ b/src/.dockerignore
@@ -1,0 +1,30 @@
+# Python virtual environments — never needed in Docker images
+**/.venv
+**/.venv-locust
+**/venv
+**/__pycache__
+**/*.pyc
+**/*.pyo
+**/*.pyd
+**/.pytest_cache
+**/.mypy_cache
+**/.ruff_cache
+
+# Test artifacts
+**/coverage.xml
+**/.coverage
+**/*.egg-info
+**/htmlcov
+**/dist
+**/build
+
+# Editor / OS
+**/.git
+**/.gitignore
+**/.DS_Store
+**/*.swp
+**/*.swo
+
+# Logs and temp files
+**/*.log
+**/tmp

--- a/src/V_APP/Data_Module/README.md
+++ b/src/V_APP/Data_Module/README.md
@@ -110,7 +110,9 @@ Data_Module/
 │   ├── use_cases/                   #   Write-side command handlers
 │   │   ├── container_moved_handler.py   Inbox → lock → command → Outbox → commit
 │   │   ├── appointment_commands.py      cmd_process_decision, cmd_update_status,
-│   │   │                                cmd_update_visit_state, cmd_flag_highway_infraction
+│   │   │                                cmd_update_visit_state, cmd_flag_highway_infraction,
+│   │   │                                cmd_review_infraction
+│   │   ├── driver_handlers.py           Driver claim + session via UoW
 │   │   ├── worker_handlers.py           Worker CRUD via UoW
 │   │   ├── driver_handlers.py           Driver claim + session via UoW
 │   │   └── alert_handlers.py            Alert creation + hazmat via UoW
@@ -160,6 +162,8 @@ Data_Module/
 │   ├── simple_outbox_worker.py          Outbox relay: poll → project (Mongo+Redis)
 │   │                                    Retry: exp. backoff + jitter, DEAD_LETTER
 │   ├── migrationDBv3.sql               Schema migration (BR constraints, driver_vehicle, pending_reviews)
+│   ├── migrationDBv4.sql               State-machine refactor + infraction review columns
+│   ├── migrationDBv5.sql               RGPD: appointment.driver_license → nullable
 │   ├── triggers.sql                     PostgreSQL triggers (10 total)
 │   ├── indexes.sql                      PostgreSQL indexes (26+ total)
 │   ├── data_init_demo.py               PEI 2025 video demo data
@@ -170,7 +174,7 @@ Data_Module/
 │   ├── rate_limit.py                    Rate limiting
 │   └── shift_utils.py                  Shift schedule parsing
 │
-└── tests/                           # Test Suite (101 tests)
+└── tests/                           # Test Suite (121 tests)
     ├── conftest.py                      Shared fixtures
     ├── test_appointment_commands_uow.py UoW + Outbox integration (20 tests)
     ├── test_appointment_optimistic_concurrency.py Version checks (8 tests)
@@ -179,6 +183,8 @@ Data_Module/
     ├── test_outbox_worker_b1.py         Retry + backoff + DEAD_LETTER (28 tests)
     ├── test_manager_statistics_endpoints.py Dashboard contracts (16 tests)
     ├── test_dashboard_endpoints.py      Dashboard route validation (4 tests)
+    ├── test_infraction_review.py        cmd_review_infraction + route structure (20 tests)
+    ├── test_phase11_dead_code.py        Dead-code cleanup guards (Phase 11)
     └── test_integration.py              Full integration (requires running DBs)
 ```
 

--- a/src/V_APP/Data_Module/README.md
+++ b/src/V_APP/Data_Module/README.md
@@ -115,10 +115,11 @@ Data_Module/
 │   │   ├── driver_handlers.py           Driver claim + session via UoW
 │   │   └── alert_handlers.py            Alert creation + hazmat via UoW
 │   └── queries/                     #   Read-side query functions
-│       ├── arrival_queries.py           Appointment reads (Redis → Mongo → PG)
+│       ├── arrival_queries.py           Appointment reads (Redis → Mongo → PG); exposes is_delayed/is_unloading/is_visit_done
 │       ├── decision_queries.py          Decision processing + MongoDB events
 │       ├── manager_statistics_queries.py Dashboard aggregations
 │       ├── statistics_queries.py        Real-time counters + timeline
+│       ├── sustainability_queries.py    CO₂ estimates + waiting-time KPIs (ICCT HDV 2023)
 │       ├── driver_queries.py            Driver lookup + auth
 │       ├── worker_queries.py            Worker lookup + auth
 │       ├── alert_queries.py             Alert reads
@@ -158,7 +159,7 @@ Data_Module/
 ├── scripts/                         # Operations
 │   ├── simple_outbox_worker.py          Outbox relay: poll → project (Mongo+Redis)
 │   │                                    Retry: exp. backoff + jitter, DEAD_LETTER
-│   ├── migrationDBv2.sql               Schema migration (inbox, outbox, triggers, indexes)
+│   ├── migrationDBv3.sql               Schema migration (BR constraints, driver_vehicle, pending_reviews)
 │   ├── triggers.sql                     PostgreSQL triggers (10 total)
 │   ├── indexes.sql                      PostgreSQL indexes (26+ total)
 │   ├── data_init_demo.py               PEI 2025 video demo data
@@ -225,8 +226,8 @@ Core entities with referential integrity, triggers, and indexes.
 
 | Entity | Description |
 |--------|-------------|
-| `Appointment` | Scheduled arrivals — core aggregate with `version` (optimistic concurrency) and `arrival_id` (PRT-XXXX via SQL sequence) |
-| `Visit` | Actual gate visits with entry/exit timestamps |
+| `Appointment` | Scheduled arrivals — core aggregate with `version` (optimistic concurrency) and `arrival_id` (PRT-XXXX via SQL sequence). Status enum: `scheduled → in_transit → in_process → completed \| canceled`. Sub-states (`delayed`, `unloading`, `in_port`, `leaving_port`) are **never stored** — always computed. |
+| `Visit` | Actual gate visits with entry/exit timestamps. State enum: `in_port → unloading → done` (default `in_port` on creation — Visit only exists once truck enters). |
 | `Driver` | Truck drivers with session-based auth |
 | `Worker` | Port staff — base for Manager and Operator roles |
 | `Company` | Transport companies (NIF) |
@@ -239,7 +240,9 @@ Core entities with referential integrity, triggers, and indexes.
 
 **Triggers (10):** arrival_id sequence, status transition validation, visit auto-completion, entry_time auto-set, alert timestamp, shift_alert_history linking, created_at for booking/worker/driver.
 
-**Migration:** `scripts/migrationDBv2.sql` — safe to re-run (IF NOT EXISTS, OR REPLACE).
+**Migrations:**
+- `scripts/migrationDBv3.sql` — BR constraints, `driver_vehicle` table, `pending_reviews` queue, auth session columns removal. Safe to re-run (IF NOT EXISTS guards). Date: 2026-04-21.
+- `scripts/migrationDBv4.sql` — state-machine refactor (2026-05): `delivery_status` enum (`in_port`/`unloading`/`done`, removes `not_started`); `appointment_status` enum removes legacy `unloading`/`delayed` stored values; backfill of existing rows.
 
 ### MongoDB — Event Store + CQRS Read Models
 
@@ -289,7 +292,7 @@ Core entities with referential integrity, triggers, and indexes.
 | GET | `/arrivals/next/{gate_id}` | Next arrivals for gate |
 | GET | `/arrivals/query/license-plate/{plate}` | Query by license plate |
 | POST | `/arrivals/{id}/decision` | Process operator decision |
-| PATCH | `/arrivals/{id}/highway-infraction` | Flag highway infraction |
+| PATCH | `/arrivals/{id}/highway-infraction` | Flag highway infraction — **only allowed when `status == in_transit`** (409 otherwise) |
 
 ### Decisions (Decision Engine Integration)
 
@@ -336,6 +339,8 @@ Core entities with referential integrity, triggers, and indexes.
 | GET | `/statistics/by-company` | Stats by transport company |
 | GET | `/statistics/volume` | Volume over time |
 | GET | `/statistics/alerts` | Alert breakdown |
+| GET | `/statistics/sustainability/summary` | CO₂ estimate + avg waiting KPIs for date range |
+| GET | `/statistics/sustainability/trend` | Time-series CO₂ + waiting (day/week/month, max 52 periods) |
 
 ### Notifications & Events
 
@@ -401,9 +406,53 @@ PYTHONPATH=. tests/.venv/bin/python -m pytest tests/test_integration.py -v
 ### Database Migration
 
 ```bash
-# Apply schema v2 (safe to re-run)
-psql -U porto -d porto_logistica -f scripts/migrationDBv2.sql
+# Base schema (inbox, outbox, triggers, indexes) — safe to re-run
+psql -U pei_user -d IntelligentLogistics -f scripts/migrationDBv3.sql
+
+# State-machine refactor (2026-05) — enum backfill + new values
+psql -U pei_user -d IntelligentLogistics -f scripts/migrationDBv4.sql
 ```
+
+---
+
+## Appointment & Visit State Machine
+
+### Appointment (`appointment.status`)
+
+Stored values (never `delayed`, `unloading`, or `leaving_port`):
+
+```
+scheduled ──► in_transit ──► in_process ──► completed
+    │               │                           ▲
+    └───────────────┴───────────► canceled      │
+                                                │
+                           (driver confirms exit via app)
+```
+
+Computed sub-states (derived at read time by `Appointment.computed_status`):
+
+| Computed value | Condition | Stored `status` |
+|---|---|---|
+| `delayed` | `now() > scheduled_start_time + 15min` | `scheduled` or `in_transit` |
+| `in_port` | `visit.state == 'in_port'` | `in_process` |
+| `unloading` | `visit.state == 'unloading'` | `in_process` |
+| `leaving_port` | `visit.state == 'done'` | `in_process` |
+
+API responses include both `primary_status` (stored) and `display_status` (computed), plus boolean flags `is_delayed`, `is_unloading`, `is_visit_done`.
+
+### Visit (`visit.state`)
+
+Created when the truck enters the port. Initial state is always `in_port`.
+
+```
+in_port ──► unloading ──► done
+```
+
+`done` means unloading is complete and the driver is heading to the exit gate. The appointment only transitions to `completed` when the driver explicitly confirms exit (manual, until automatic gate detection is implemented).
+
+### Highway Infraction Guard
+
+`PATCH /arrivals/{id}/highway-infraction` returns **409 Conflict** if `appointment.status` is not `in_transit`. A truck already inside the port cannot receive a highway infraction flag.
 
 ---
 

--- a/src/V_APP/Data_Module/application/queries/arrival_queries.py
+++ b/src/V_APP/Data_Module/application/queries/arrival_queries.py
@@ -20,36 +20,21 @@ from infrastructure.persistence.sql_models import (
 
 
 def _delayed_condition():
-    """SQLAlchemy condition: appointment is effectively delayed.
+    """SQLAlchemy condition: scheduled appointment is past the delay threshold.
 
-    Matches rows stored as 'delayed' (backward compat) and rows that are
-    'in_transit' past the delay tolerance threshold.
+    Only applies to 'scheduled' status (truck hasn't departed yet).
+    In-transit trucks that are late are returned by the 'in_transit' filter
+    with is_delayed=True on the appointment object — they do not appear here.
 
     scheduled_start_time is stored as UTC naive datetime (Docker containers
     run with TZ=UTC). cutoff uses UTC naive to match.
     """
     from datetime import timezone as _tz
     cutoff = datetime.now(_tz.utc).replace(tzinfo=None) - timedelta(minutes=DELAY_TOLERANCE_MINUTES)
-    return or_(
-        Appointment.status == 'delayed',
-        and_(
-            Appointment.status == 'in_transit',
-            Appointment.scheduled_start_time.isnot(None),
-            Appointment.scheduled_start_time < cutoff,
-        ),
-    )
-
-
-def _in_transit_ontime_condition():
-    """SQLAlchemy condition: in_transit and not yet past the delay threshold."""
-    from datetime import timezone as _tz
-    cutoff = datetime.now(_tz.utc).replace(tzinfo=None) - timedelta(minutes=DELAY_TOLERANCE_MINUTES)
     return and_(
-        Appointment.status == 'in_transit',
-        or_(
-            Appointment.scheduled_start_time.is_(None),
-            Appointment.scheduled_start_time >= cutoff,
-        ),
+        Appointment.status == 'scheduled',
+        Appointment.scheduled_start_time.isnot(None),
+        Appointment.scheduled_start_time < cutoff,
     )
 
 
@@ -59,20 +44,15 @@ def _unloading_condition():
     Matches in_process appointments with an active Visit in unloading state,
     plus backward-compat rows stored with status='unloading'.
     """
-    return or_(
-        Appointment.status == 'unloading',
-        and_(
-            Appointment.status == 'in_process',
-            Appointment.id.in_(
-                # subquery: appointment_ids with an active unloading Visit
-                # (using a raw subselect to avoid JOIN conflicts in callers)
-                __import__('sqlalchemy').select(Visit.appointment_id).where(
-                    and_(
-                        Visit.state == 'unloading',
-                        Visit.out_time.is_(None),
-                    )
+    return and_(
+        Appointment.status == 'in_process',
+        Appointment.id.in_(
+            __import__('sqlalchemy').select(Visit.appointment_id).where(
+                and_(
+                    Visit.state == 'unloading',
+                    Visit.out_time.is_(None),
                 )
-            ),
+            )
         ),
     )
 
@@ -83,15 +63,17 @@ def _resolve_status_filter(status: str):
     Handles virtual sub-states 'delayed' and 'unloading' that are no longer
     stored as primary values in Appointment.status.
 
-    'in_transit' maps to on-time only — delayed in_transit appointments are
-    returned by 'delayed' filter instead, keeping the two filters disjoint.
+    'in_transit'  → all in_transit rows (on-time and delayed); is_delayed flag
+                    distinguishes them in the API response.
+    'delayed'     → only scheduled rows past the tolerance (trucks not yet departed).
+    'unloading'   → in_process rows with an active Visit in unloading state.
     """
     if status == 'delayed':
         return _delayed_condition()
     if status == 'unloading':
         return _unloading_condition()
     if status == 'in_transit':
-        return _in_transit_ontime_condition()
+        return Appointment.status == 'in_transit'
     return Appointment.status == status
 
 
@@ -393,6 +375,7 @@ def get_appointments_for_decision(db: Session, gate_id: Optional[int] = None) ->
             "primary_status": a.status,            # raw DB state (never delayed/unloading)
             "is_delayed": a.is_delayed,
             "is_unloading": a.is_unloading,
+            "is_visit_done": a.is_visit_done,
             "highway_infraction": a.highway_infraction,
             "cargo": cargo,
             "booking": {
@@ -423,11 +406,23 @@ def get_appointments_count_by_status(
     def _q(condition):
         return db.query(func.count(Appointment.id)).filter(condition, *gate_filter)
 
-    scheduled_count   = _q(and_(Appointment.status == "scheduled",   Appointment.scheduled_start_time.between(start_dt, end_dt))).scalar() or 0
-    in_transit_count  = _q(and_(_in_transit_ontime_condition(),       Appointment.scheduled_start_time.between(start_dt, end_dt))).scalar() or 0
-    delayed_count     = _q(_delayed_condition()).scalar() or 0
-    in_process_count  = _q(and_(Appointment.status == "in_process",  Appointment.scheduled_start_time.between(start_dt, end_dt))).scalar() or 0
+    # scheduled on-time: exclude rows that are already delayed (past tolerance)
+    from datetime import timezone as _tz
+    _cutoff = datetime.now(_tz.utc).replace(tzinfo=None) - timedelta(minutes=DELAY_TOLERANCE_MINUTES)
+    scheduled_count   = _q(and_(
+        Appointment.status == "scheduled",
+        Appointment.scheduled_start_time.between(start_dt, end_dt),
+        or_(
+            Appointment.scheduled_start_time.is_(None),
+            Appointment.scheduled_start_time >= _cutoff,
+        ),
+    )).scalar() or 0
+    in_transit_count  = _q(and_(Appointment.status == "in_transit",   Appointment.scheduled_start_time.between(start_dt, end_dt))).scalar() or 0
+    delayed_count     = _q(and_(_delayed_condition(),                  Appointment.scheduled_start_time.between(start_dt, end_dt))).scalar() or 0
+    # Unloading is a sub-state of in_process: exclude those rows from in_process_count
+    # so the two counts are disjoint and summing them gives the true total.
     unloading_count   = _q(and_(_unloading_condition(),               Appointment.scheduled_start_time.between(start_dt, end_dt))).scalar() or 0
+    in_process_count  = _q(and_(Appointment.status == "in_process",  ~_unloading_condition(), Appointment.scheduled_start_time.between(start_dt, end_dt))).scalar() or 0
     completed_count   = _q(and_(Appointment.status == "completed",   Appointment.scheduled_start_time.between(start_dt, end_dt))).scalar() or 0
     canceled_count    = _q(and_(Appointment.status == "canceled",    Appointment.scheduled_start_time.between(start_dt, end_dt))).scalar() or 0
     infractions_count = db.query(func.count(Appointment.id)).filter(

--- a/src/V_APP/Data_Module/application/queries/driver_queries.py
+++ b/src/V_APP/Data_Module/application/queries/driver_queries.py
@@ -141,6 +141,53 @@ def get_driver_today_appointments(drivers_license: str) -> List[Dict[str, Any]]:
         db.close()
 
 
+def get_available_bookings_for_driver(
+    company_nif: str,
+    *,
+    page: int = 1,
+    limit: int = 20,
+) -> Dict[str, Any]:
+    """Unclaimed scheduled appointments for trucks belonging to `company_nif`.
+
+    An appointment is 'available' when:
+    - driver_license IS NULL (no driver assigned yet)
+    - status = 'scheduled'
+    - The truck is owned by the driver's company (Truck.company_nif == company_nif)
+    """
+    from infrastructure.persistence.postgres import SessionLocal
+    from infrastructure.persistence.sql_models import (
+        Appointment as AppointmentORM,
+        Truck as TruckORM,
+    )
+    from application.schemas import Appointment as AppointmentSchema
+
+    db = SessionLocal()
+    try:
+        q = (
+            db.query(AppointmentORM)
+            .options(*_appointment_eager_options())
+            .join(TruckORM, AppointmentORM.truck_license_plate == TruckORM.license_plate)
+            .filter(
+                AppointmentORM.driver_license.is_(None),
+                AppointmentORM.status == "scheduled",
+                TruckORM.company_nif == company_nif,
+            )
+            .order_by(AppointmentORM.scheduled_start_time)
+        )
+        total = q.count()
+        rows = q.offset((page - 1) * limit).limit(limit).all()
+        items = [AppointmentSchema.model_validate(r).model_dump(mode="json") for r in rows]
+        return {
+            "items": items,
+            "total": total,
+            "page": page,
+            "limit": limit,
+            "pages": max(1, -(-total // limit)),
+        }
+    finally:
+        db.close()
+
+
 def get_driver_appointments(
     drivers_license: str,
     *,

--- a/src/V_APP/Data_Module/application/queries/driver_queries.py
+++ b/src/V_APP/Data_Module/application/queries/driver_queries.py
@@ -101,7 +101,7 @@ def get_driver_active_appointment(drivers_license: str) -> Optional[Dict[str, An
             .options(*_appointment_eager_options())
             .filter(
                 AppointmentORM.driver_license == drivers_license,
-                AppointmentORM.status.in_(["in_transit", "delayed", "in_process", "unloading"])
+                AppointmentORM.status.in_(["in_transit", "in_process"])
             )
             .order_by(AppointmentORM.scheduled_start_time)
             .first()

--- a/src/V_APP/Data_Module/application/queries/manager_statistics_queries.py
+++ b/src/V_APP/Data_Module/application/queries/manager_statistics_queries.py
@@ -30,6 +30,7 @@ from infrastructure.persistence.sql_models import (
     Dock,
     Truck,
     Visit,
+    DELAY_TOLERANCE_MINUTES,
 )
 
 logger = logging.getLogger("manager_statistics_queries")
@@ -93,8 +94,12 @@ def get_dashboard_summary(target_date: Optional[str] = None) -> Dict[str, Any]:
         total_appointments = base.count()
 
         # Status counts
-        _delay_cutoff = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(minutes=1)
-        scheduled_count = base.filter(Appointment.status == "scheduled").count()
+        _delay_cutoff = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(minutes=DELAY_TOLERANCE_MINUTES)
+        # scheduled on-time: exclude rows already past the delay threshold
+        scheduled_count = base.filter(
+            Appointment.status == "scheduled",
+            or_(Appointment.scheduled_start_time.is_(None), Appointment.scheduled_start_time >= _delay_cutoff),
+        ).count()
         in_transit_count = base.filter(
             Appointment.status == "in_transit",
             or_(Appointment.scheduled_start_time.is_(None), Appointment.scheduled_start_time >= _delay_cutoff),
@@ -104,20 +109,15 @@ def get_dashboard_summary(target_date: Optional[str] = None) -> Dict[str, Any]:
             and_(Visit.state == 'unloading', Visit.out_time.is_(None))
         )
         unloading_count = base.filter(
-            or_(
-                Appointment.status == "unloading",
-                and_(Appointment.status == "in_process", Appointment.id.in_(_active_unloading_ids)),
-            )
+            and_(Appointment.status == "in_process", Appointment.id.in_(_active_unloading_ids))
         ).count()
         completed_count = base.filter(Appointment.status == "completed").count()
+        # delayed: both 'scheduled' and 'in_transit' past the tolerance threshold
         delayed_count = base.filter(
-            or_(
-                Appointment.status == "delayed",
-                and_(
-                    Appointment.status == "in_transit",
-                    Appointment.scheduled_start_time.isnot(None),
-                    Appointment.scheduled_start_time < _delay_cutoff,
-                ),
+            and_(
+                Appointment.status.in_(("scheduled", "in_transit")),
+                Appointment.scheduled_start_time.isnot(None),
+                Appointment.scheduled_start_time < _delay_cutoff,
             )
         ).count()
 

--- a/src/V_APP/Data_Module/application/queries/manager_statistics_queries.py
+++ b/src/V_APP/Data_Module/application/queries/manager_statistics_queries.py
@@ -94,16 +94,15 @@ def get_dashboard_summary(target_date: Optional[str] = None) -> Dict[str, Any]:
         total_appointments = base.count()
 
         # Status counts
-        _delay_cutoff = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(minutes=DELAY_TOLERANCE_MINUTES)
-        # scheduled on-time: exclude rows already past the delay threshold
-        scheduled_count = base.filter(
-            Appointment.status == "scheduled",
-            or_(Appointment.scheduled_start_time.is_(None), Appointment.scheduled_start_time >= _delay_cutoff),
-        ).count()
-        in_transit_count = base.filter(
-            Appointment.status == "in_transit",
-            or_(Appointment.scheduled_start_time.is_(None), Appointment.scheduled_start_time >= _delay_cutoff),
-        ).count()
+        now_utc = datetime.now(timezone.utc)
+        # Strip tzinfo when comparing with naive DB timestamps
+        _now_naive = now_utc.replace(tzinfo=None)
+        _delay_cutoff = _now_naive - timedelta(minutes=DELAY_TOLERANCE_MINUTES)
+
+        # Bug fix: count ALL scheduled (not just on-time) for display consistency
+        scheduled_count = base.filter(Appointment.status == "scheduled").count()
+        # Count ALL in_transit (delayed + on-time) — the "delayed" badge is a separate sub-metric
+        in_transit_count = base.filter(Appointment.status == "in_transit").count()
         in_process_count = base.filter(Appointment.status == "in_process").count()
         _active_unloading_ids = select(Visit.appointment_id).where(
             and_(Visit.state == 'unloading', Visit.out_time.is_(None))
@@ -112,17 +111,19 @@ def get_dashboard_summary(target_date: Optional[str] = None) -> Dict[str, Any]:
             and_(Appointment.status == "in_process", Appointment.id.in_(_active_unloading_ids))
         ).count()
         completed_count = base.filter(Appointment.status == "completed").count()
-        # delayed: both 'scheduled' and 'in_transit' past the tolerance threshold
+
+        # Bug fix: trucksInPort = in_process only.
+        # unloading_count is a subset of in_process (shown as sub-label), not additional trucks.
+        trucks_in_port = in_process_count
+
+        # Currently-delayed in_transit trucks (for the "X delayed" badge on the In Transit KPI)
         delayed_count = base.filter(
             and_(
-                Appointment.status.in_(("scheduled", "in_transit")),
+                Appointment.status == "in_transit",
                 Appointment.scheduled_start_time.isnot(None),
                 Appointment.scheduled_start_time < _delay_cutoff,
             )
         ).count()
-
-        # Trucks actually inside the port: in_process + unloading
-        trucks_in_port = in_process_count + unloading_count
 
         # Infraction count
         infraction_count = base.filter(
@@ -144,7 +145,7 @@ def get_dashboard_summary(target_date: Optional[str] = None) -> Dict[str, Any]:
             .scalar()
         ) or 0
 
-        # Average permanence (minutes) for visits that have both entry and exit today
+        # Average permanence (minutes) for visits with both entry and exit today
         avg_perm = (
             db.query(
                 func.avg(
@@ -160,38 +161,86 @@ def get_dashboard_summary(target_date: Optional[str] = None) -> Dict[str, Any]:
         )
         avg_permanence = round(float(avg_perm), 1) if avg_perm else 0.0
 
-        # Average waiting time (minutes): entry_time - scheduled_start_time
+        # Average waiting time: MAX(0, entry_time - scheduled_start_time).
+        # Bug fixes:
+        #   - Use func.greatest(0, ...) to clamp negative values (early arrivals).
+        #   - Only include appointments scheduled today to avoid cross-day contamination.
         avg_wait = (
             db.query(
                 func.avg(
-                    extract(
-                        "epoch",
-                        Visit.entry_time - Appointment.scheduled_start_time,
+                    func.greatest(
+                        0.0,
+                        extract(
+                            "epoch",
+                            Visit.entry_time - Appointment.scheduled_start_time,
+                        ) / 60,
                     )
-                    / 60
                 )
             )
             .join(Appointment, Visit.appointment_id == Appointment.id)
             .filter(
                 Visit.entry_time.isnot(None),
                 Visit.entry_time.between(day_start, day_end),
+                Appointment.scheduled_start_time.isnot(None),
+                Appointment.scheduled_start_time.between(day_start, day_end),
             )
             .scalar()
         )
         avg_waiting = round(float(avg_wait), 1) if avg_wait else 0.0
 
-        # Delay rate
+        # --- Delay rate ---
+        # Currently delayed (pending trucks past cutoff)
+        currently_delayed = base.filter(
+            and_(
+                Appointment.status.in_(("scheduled", "in_transit")),
+                Appointment.scheduled_start_time.isnot(None),
+                Appointment.scheduled_start_time < _delay_cutoff,
+            )
+        ).count()
+        # Historically delayed: completed trucks that arrived after their tolerance window
+        historically_delayed = (
+            base.join(Visit, Visit.appointment_id == Appointment.id)
+            .filter(
+                Appointment.status == "completed",
+                Visit.entry_time.isnot(None),
+                Appointment.scheduled_start_time.isnot(None),
+                Visit.entry_time > Appointment.scheduled_start_time + timedelta(minutes=DELAY_TOLERANCE_MINUTES),
+            )
+            .count()
+        )
+        total_delayed = currently_delayed + historically_delayed
         delay_rate = (
-            round(delayed_count / total_appointments * 100, 1)
+            round(total_delayed / total_appointments * 100, 1)
             if total_appointments > 0
             else 0.0
         )
 
-        # SLA compliance = completed on time / (completed + delayed) * 100
-        sla_denominator = completed_count + delayed_count
+        # --- SLA compliance ---
+        # Correct formula: of completed appointments (with a scheduled time), what fraction
+        # arrived within the tolerance window?  Avoids mixing real-time snapshot with
+        # historical counts that produced the double-counting bug.
+        completed_with_schedule = (
+            base.join(Visit, Visit.appointment_id == Appointment.id)
+            .filter(
+                Appointment.status == "completed",
+                Visit.entry_time.isnot(None),
+                Appointment.scheduled_start_time.isnot(None),
+            )
+            .count()
+        )
+        completed_on_time = (
+            base.join(Visit, Visit.appointment_id == Appointment.id)
+            .filter(
+                Appointment.status == "completed",
+                Visit.entry_time.isnot(None),
+                Appointment.scheduled_start_time.isnot(None),
+                Visit.entry_time <= Appointment.scheduled_start_time + timedelta(minutes=DELAY_TOLERANCE_MINUTES),
+            )
+            .count()
+        )
         sla_compliance = (
-            round(completed_count / sla_denominator * 100, 1)
-            if sla_denominator > 0
+            round(completed_on_time / completed_with_schedule * 100, 1)
+            if completed_with_schedule > 0
             else 100.0
         )
 
@@ -224,7 +273,6 @@ def get_dashboard_summary(target_date: Optional[str] = None) -> Dict[str, Any]:
         )
 
         # Vehicles per hour: total movements / elapsed hours today
-        now_utc = datetime.now(timezone.utc)
         elapsed_hours = max(
             (now_utc - day_start).total_seconds() / 3600, 1.0
         )
@@ -281,6 +329,15 @@ def get_dashboard_summary(target_date: Optional[str] = None) -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 def _transport_stats_from_pg(start, end) -> List[Dict[str, Any]]:
+    """
+    Per-company transport stats computed from PostgreSQL.
+
+    SLA fix: old formula used completed/ops_count which counted in-progress
+    appointments as "failures".  Correct formula:
+        sla_rate = arrived_on_time / completed_with_schedule
+    where "on time" = entry_time <= scheduled_start_time + DELAY_TOLERANCE_MINUTES.
+    avg_waiting uses MAX(0, entry-scheduled) to exclude negative values (early arrivals).
+    """
     db: Session = SessionLocal()
     try:
         rows = (
@@ -288,22 +345,41 @@ def _transport_stats_from_pg(start, end) -> List[Dict[str, Any]]:
                 Company.name.label("company_name"),
                 Company.nif.label("company_nif"),
                 func.count(Appointment.id).label("ops_count"),
+                # avg unloading: out_time - entry_time (always positive when both present)
                 func.avg(
                     extract("epoch", Visit.out_time - Visit.entry_time) / 60
                 ).label("avg_unloading"),
+                # avg waiting: MAX(0, entry_time - scheduled_start_time)
                 func.avg(
-                    extract(
-                        "epoch",
-                        Visit.entry_time - Appointment.scheduled_start_time,
+                    func.greatest(
+                        0.0,
+                        extract("epoch", Visit.entry_time - Appointment.scheduled_start_time) / 60,
                     )
-                    / 60
                 ).label("avg_waiting"),
+                # completed with a known scheduled_start_time (denominator for SLA)
                 func.sum(
                     case(
-                        (Appointment.status == "completed", 1),
+                        (and_(
+                            Appointment.status == "completed",
+                            Appointment.scheduled_start_time.isnot(None),
+                            Visit.entry_time.isnot(None),
+                        ), 1),
                         else_=0,
                     )
-                ).label("completed_count"),
+                ).label("completed_with_schedule"),
+                # arrived on time: completed + entry within tolerance
+                func.sum(
+                    case(
+                        (and_(
+                            Appointment.status == "completed",
+                            Appointment.scheduled_start_time.isnot(None),
+                            Visit.entry_time.isnot(None),
+                            extract("epoch", Visit.entry_time - Appointment.scheduled_start_time) / 60
+                            <= DELAY_TOLERANCE_MINUTES,
+                        ), 1),
+                        else_=0,
+                    )
+                ).label("arrived_on_time"),
             )
             .join(Truck, Appointment.truck_license_plate == Truck.license_plate)
             .join(Company, Truck.company_nif == Company.nif)
@@ -315,8 +391,13 @@ def _transport_stats_from_pg(start, end) -> List[Dict[str, Any]]:
         result = []
         for r in rows:
             ops = r.ops_count or 0
-            completed = r.completed_count or 0
-            sla_rate = round(completed / ops * 100, 1) if ops > 0 else 0.0
+            completed_with_schedule = r.completed_with_schedule or 0
+            arrived_on_time = r.arrived_on_time or 0
+            sla_rate = (
+                round(arrived_on_time / completed_with_schedule * 100, 1)
+                if completed_with_schedule > 0
+                else 0.0
+            )
             result.append({
                 "companyName": r.company_name,
                 "companyNif": r.company_nif,
@@ -399,8 +480,37 @@ def compute_company_metrics_snapshot(db_session: Session, period_days: int = 30)
                     / 60
                 ).label("avg_waiting"),
                 func.sum(
-                    case((Appointment.status == "completed", 1), else_=0)
-                ).label("completed_count"),
+                    case(
+                        (
+                            and_(
+                                Appointment.status == "completed",
+                                Appointment.scheduled_start_time.isnot(None),
+                                Visit.entry_time.isnot(None),
+                            ),
+                            1,
+                        ),
+                        else_=0,
+                    )
+                ).label("completed_with_schedule"),
+                func.sum(
+                    case(
+                        (
+                            and_(
+                                Appointment.status == "completed",
+                                Appointment.scheduled_start_time.isnot(None),
+                                Visit.entry_time.isnot(None),
+                                extract(
+                                    "epoch",
+                                    Visit.entry_time - Appointment.scheduled_start_time,
+                                )
+                                / 60
+                                <= DELAY_TOLERANCE_MINUTES,
+                            ),
+                            1,
+                        ),
+                        else_=0,
+                    )
+                ).label("arrived_on_time"),
             )
             .join(Truck, Appointment.truck_license_plate == Truck.license_plate)
             .join(Company, Truck.company_nif == Company.nif)
@@ -413,8 +523,13 @@ def compute_company_metrics_snapshot(db_session: Session, period_days: int = 30)
         count = 0
         for r in rows:
             ops = r.ops_count or 0
-            completed = r.completed_count or 0
-            sla_rate = round(completed / ops * 100, 1) if ops > 0 else 0.0
+            completed_with_schedule = r.completed_with_schedule or 0
+            arrived_on_time = r.arrived_on_time or 0
+            sla_rate = (
+                round(arrived_on_time / completed_with_schedule * 100, 1)
+                if completed_with_schedule > 0
+                else 0.0
+            )
             doc = {
                 "company_nif": r.company_nif,
                 "company_name": r.company_name,

--- a/src/V_APP/Data_Module/application/queries/manager_statistics_queries.py
+++ b/src/V_APP/Data_Module/application/queries/manager_statistics_queries.py
@@ -473,11 +473,14 @@ def compute_company_metrics_snapshot(db_session: Session, period_days: int = 30)
                     extract("epoch", Visit.out_time - Visit.entry_time) / 60
                 ).label("avg_unloading"),
                 func.avg(
-                    extract(
-                        "epoch",
-                        Visit.entry_time - Appointment.scheduled_start_time,
+                    func.greatest(
+                        0.0,
+                        extract(
+                            "epoch",
+                            Visit.entry_time - Appointment.scheduled_start_time,
+                        )
+                        / 60,
                     )
-                    / 60
                 ).label("avg_waiting"),
                 func.sum(
                     case(

--- a/src/V_APP/Data_Module/application/queries/sustainability_queries.py
+++ b/src/V_APP/Data_Module/application/queries/sustainability_queries.py
@@ -79,12 +79,12 @@ def get_sustainability_summary(
     {
         "avg_waiting_minutes": float,
         "total_co2_kg_estimate": float,
-        "appointments_with_delay": int,    # waiting > DELAY_THRESHOLD_MINUTES
+        "trucks_delayed": int,             # waiting > DELAY_THRESHOLD_MINUTES
         "trucks_processed": int,           # appointments with known entry_time
         "appointments_excluded": int,      # no scheduled_start_time → excluded
-        "co2_per_truck_avg_kg": float,
-        "period_from": str,                # ISO date
-        "period_to": str,
+        "avg_co2_per_truck_kg": float,
+        "from_date": str,                  # ISO date
+        "to_date": str,
         "methodology": str,
     }
     """
@@ -121,12 +121,13 @@ def get_sustainability_summary(
             return {
                 "avg_waiting_minutes": 0.0,
                 "total_co2_kg_estimate": 0.0,
-                "appointments_with_delay": 0,
+                "trucks_delayed": 0,
                 "trucks_processed": 0,
                 "appointments_excluded": excluded,
-                "co2_per_truck_avg_kg": 0.0,
-                "period_from": start.date().isoformat(),
-                "period_to": end.date().isoformat(),
+                "avg_co2_per_truck_kg": 0.0,
+                "wait_distribution": {"0_5": 0, "5_15": 0, "15_30": 0, "over_30": 0},
+                "from_date": start.date().isoformat(),
+                "to_date": end.date().isoformat(),
                 "methodology": f"ICCT HDV 2023 + EU JRC — {TRUCK_IDLE_CO2_KG_PER_HOUR} kg CO₂/h idling (Euro VI)",
             }
 
@@ -141,15 +142,23 @@ def get_sustainability_summary(
         co2_avg = round(total_co2 / trucks_processed, 2) if trucks_processed else 0.0
         delayed = sum(1 for w in waiting_minutes if w > DELAY_THRESHOLD_MINUTES)
 
+        wait_distribution = {
+            "0_5":    sum(1 for w in waiting_minutes if w <= 5),
+            "5_15":   sum(1 for w in waiting_minutes if 5 < w <= 15),
+            "15_30":  sum(1 for w in waiting_minutes if 15 < w <= 30),
+            "over_30": sum(1 for w in waiting_minutes if w > 30),
+        }
+
         return {
             "avg_waiting_minutes": avg_waiting,
             "total_co2_kg_estimate": total_co2,
-            "appointments_with_delay": delayed,
+            "trucks_delayed": delayed,
             "trucks_processed": trucks_processed,
             "appointments_excluded": excluded,
-            "co2_per_truck_avg_kg": co2_avg,
-            "period_from": start.date().isoformat(),
-            "period_to": end.date().isoformat(),
+            "avg_co2_per_truck_kg": co2_avg,
+            "wait_distribution": wait_distribution,
+            "from_date": start.date().isoformat(),
+            "to_date": end.date().isoformat(),
             "methodology": f"ICCT HDV 2023 + EU JRC — {TRUCK_IDLE_CO2_KG_PER_HOUR} kg CO₂/h idling (Euro VI)",
         }
     except Exception:
@@ -157,12 +166,13 @@ def get_sustainability_summary(
         return {
             "avg_waiting_minutes": 0.0,
             "total_co2_kg_estimate": 0.0,
-            "appointments_with_delay": 0,
+            "trucks_delayed": 0,
             "trucks_processed": 0,
             "appointments_excluded": 0,
-            "co2_per_truck_avg_kg": 0.0,
-            "period_from": start.date().isoformat(),
-            "period_to": end.date().isoformat(),
+            "avg_co2_per_truck_kg": 0.0,
+            "wait_distribution": {"0_5": 0, "5_15": 0, "15_30": 0, "over_30": 0},
+            "from_date": start.date().isoformat(),
+            "to_date": end.date().isoformat(),
             "methodology": f"ICCT HDV 2023 + EU JRC — {TRUCK_IDLE_CO2_KG_PER_HOUR} kg CO₂/h idling (Euro VI)",
         }
     finally:

--- a/src/V_APP/Data_Module/application/queries/sustainability_queries.py
+++ b/src/V_APP/Data_Module/application/queries/sustainability_queries.py
@@ -1,0 +1,248 @@
+"""
+Sustainability queries for the Logistics Manager frontend.
+
+Provides CO₂ estimates based on truck idle time at the gate.
+Methodology: ICCT HDV Roadmap 2023 + EU JRC — 0.84 kg CO₂/hour idling
+for a Euro VI heavy-duty truck. Waiting time = MAX(0, entry_time - scheduled_start_time).
+Appointments without scheduled_start_time are excluded from CO₂ calculations.
+
+Endpoints consumed:
+  GET /statistics/sustainability/summary   → SustainabilitySummary
+  GET /statistics/sustainability/trend     → SustainabilityTrendPoint[]
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, time, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy import and_, cast, extract, func, Float
+from sqlalchemy.orm import Session
+
+from infrastructure.persistence.postgres import SessionLocal
+from infrastructure.persistence.sql_models import Appointment, Visit
+
+logger = logging.getLogger("sustainability_queries")
+
+# ICCT HDV Roadmap 2023 + EU JRC — Euro VI heavy-duty truck idle emissions
+TRUCK_IDLE_CO2_KG_PER_HOUR: float = 0.84
+TRUCK_IDLE_CO2_KG_PER_MIN: float = TRUCK_IDLE_CO2_KG_PER_HOUR / 60
+DELAY_THRESHOLD_MINUTES: int = 15
+
+
+def _parse_date_range(
+    from_str: Optional[str], to_str: Optional[str]
+) -> tuple[datetime, datetime]:
+    """Return (start, end) UTC datetimes. Defaults to current week (Mon–Sun)."""
+    today = datetime.now(timezone.utc).date()
+    if from_str:
+        d_from = datetime.strptime(from_str, "%Y-%m-%d").date()
+    else:
+        d_from = today - timedelta(days=today.weekday())
+    if to_str:
+        d_to = datetime.strptime(to_str, "%Y-%m-%d").date()
+    else:
+        d_to = today
+
+    start = datetime.combine(d_from, time.min, tzinfo=timezone.utc)
+    end = datetime.combine(d_to, time.max, tzinfo=timezone.utc)
+    return start, end
+
+
+def _waiting_minutes_expr():
+    """
+    SQLAlchemy expression: MAX(0, entry_time - scheduled_start_time) in minutes.
+    Only computed when both fields are present.
+    """
+    return func.greatest(
+        0.0,
+        cast(
+            extract("epoch", Visit.entry_time - Appointment.scheduled_start_time) / 60,
+            Float,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. GET /statistics/sustainability/summary
+# ---------------------------------------------------------------------------
+
+def get_sustainability_summary(
+    from_date: Optional[str] = None,
+    to_date: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Returns CO₂ and waiting-time KPIs for the given date range.
+
+    Response shape:
+    {
+        "avg_waiting_minutes": float,
+        "total_co2_kg_estimate": float,
+        "appointments_with_delay": int,    # waiting > DELAY_THRESHOLD_MINUTES
+        "trucks_processed": int,           # appointments with known entry_time
+        "appointments_excluded": int,      # no scheduled_start_time → excluded
+        "co2_per_truck_avg_kg": float,
+        "period_from": str,                # ISO date
+        "period_to": str,
+        "methodology": str,
+    }
+    """
+    start, end = _parse_date_range(from_date, to_date)
+    db: Session = SessionLocal()
+    try:
+        # Base: appointments with entry_time in range + scheduled_start_time known
+        base_q = (
+            db.query(Appointment, Visit)
+            .join(Visit, Visit.appointment_id == Appointment.id)
+            .filter(
+                Visit.entry_time.isnot(None),
+                Visit.entry_time.between(start, end),
+                Appointment.scheduled_start_time.isnot(None),
+            )
+        )
+
+        rows = base_q.all()
+        trucks_processed = len(rows)
+
+        # Appointments in range but without scheduled_start_time (excluded)
+        excluded = (
+            db.query(func.count(Appointment.id))
+            .join(Visit, Visit.appointment_id == Appointment.id)
+            .filter(
+                Visit.entry_time.isnot(None),
+                Visit.entry_time.between(start, end),
+                Appointment.scheduled_start_time.is_(None),
+            )
+            .scalar()
+        ) or 0
+
+        if trucks_processed == 0:
+            return {
+                "avg_waiting_minutes": 0.0,
+                "total_co2_kg_estimate": 0.0,
+                "appointments_with_delay": 0,
+                "trucks_processed": 0,
+                "appointments_excluded": excluded,
+                "co2_per_truck_avg_kg": 0.0,
+                "period_from": start.date().isoformat(),
+                "period_to": end.date().isoformat(),
+                "methodology": f"ICCT HDV 2023 + EU JRC — {TRUCK_IDLE_CO2_KG_PER_HOUR} kg CO₂/h idling (Euro VI)",
+            }
+
+        waiting_minutes: list[float] = []
+        for appt, visit in rows:
+            diff = (visit.entry_time - appt.scheduled_start_time).total_seconds() / 60
+            waiting_minutes.append(max(0.0, diff))
+
+        avg_waiting = round(sum(waiting_minutes) / len(waiting_minutes), 1)
+        total_waiting = sum(waiting_minutes)
+        total_co2 = round(total_waiting * TRUCK_IDLE_CO2_KG_PER_MIN, 2)
+        co2_avg = round(total_co2 / trucks_processed, 2) if trucks_processed else 0.0
+        delayed = sum(1 for w in waiting_minutes if w > DELAY_THRESHOLD_MINUTES)
+
+        return {
+            "avg_waiting_minutes": avg_waiting,
+            "total_co2_kg_estimate": total_co2,
+            "appointments_with_delay": delayed,
+            "trucks_processed": trucks_processed,
+            "appointments_excluded": excluded,
+            "co2_per_truck_avg_kg": co2_avg,
+            "period_from": start.date().isoformat(),
+            "period_to": end.date().isoformat(),
+            "methodology": f"ICCT HDV 2023 + EU JRC — {TRUCK_IDLE_CO2_KG_PER_HOUR} kg CO₂/h idling (Euro VI)",
+        }
+    except Exception:
+        logger.exception("get_sustainability_summary failed")
+        return {
+            "avg_waiting_minutes": 0.0,
+            "total_co2_kg_estimate": 0.0,
+            "appointments_with_delay": 0,
+            "trucks_processed": 0,
+            "appointments_excluded": 0,
+            "co2_per_truck_avg_kg": 0.0,
+            "period_from": start.date().isoformat(),
+            "period_to": end.date().isoformat(),
+            "methodology": f"ICCT HDV 2023 + EU JRC — {TRUCK_IDLE_CO2_KG_PER_HOUR} kg CO₂/h idling (Euro VI)",
+        }
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# 2. GET /statistics/sustainability/trend
+# ---------------------------------------------------------------------------
+
+def get_sustainability_trend(
+    granularity: str = "day",
+    n_periods: int = 12,
+) -> List[Dict[str, Any]]:
+    """
+    Returns a time-series of CO₂ estimates and avg waiting times.
+
+    granularity: 'day' | 'week' | 'month'
+    n_periods:   number of past periods to return (max 52)
+
+    Response shape:
+    [
+      {
+        "period": "2026-05-01",         # ISO date of period start
+        "avg_waiting_minutes": float,
+        "total_co2_kg": float,
+        "trucks_processed": int,
+      },
+      ...
+    ]
+    """
+    n_periods = min(max(n_periods, 1), 52)
+
+    granularity_map = {"day": "day", "week": "week", "month": "month"}
+    trunc = granularity_map.get(granularity, "day")
+
+    now = datetime.now(timezone.utc)
+
+    if trunc == "day":
+        period_start = now - timedelta(days=n_periods)
+    elif trunc == "week":
+        period_start = now - timedelta(weeks=n_periods)
+    else:  # month
+        period_start = now - timedelta(days=n_periods * 30)
+
+    db: Session = SessionLocal()
+    try:
+        trunc_expr = func.date_trunc(trunc, Visit.entry_time)
+
+        rows = (
+            db.query(
+                trunc_expr.label("period"),
+                func.count(Appointment.id).label("trucks"),
+                func.avg(_waiting_minutes_expr()).label("avg_waiting"),
+                func.sum(_waiting_minutes_expr()).label("total_waiting"),
+            )
+            .join(Visit, Visit.appointment_id == Appointment.id)
+            .filter(
+                Visit.entry_time.isnot(None),
+                Visit.entry_time >= period_start,
+                Appointment.scheduled_start_time.isnot(None),
+            )
+            .group_by("period")
+            .order_by("period")
+            .all()
+        )
+
+        return [
+            {
+                "period": row.period.date().isoformat() if row.period else None,
+                "avg_waiting_minutes": round(float(row.avg_waiting or 0), 1),
+                "total_co2_kg": round(
+                    float(row.total_waiting or 0) * TRUCK_IDLE_CO2_KG_PER_MIN, 2
+                ),
+                "trucks_processed": row.trucks,
+            }
+            for row in rows
+        ]
+    except Exception:
+        logger.exception("get_sustainability_trend failed")
+        return []
+    finally:
+        db.close()

--- a/src/V_APP/Data_Module/application/queries/sustainability_queries.py
+++ b/src/V_APP/Data_Module/application/queries/sustainability_queries.py
@@ -215,8 +215,14 @@ def get_sustainability_trend(
         period_start = now - timedelta(days=n_periods)
     elif trunc == "week":
         period_start = now - timedelta(weeks=n_periods)
-    else:  # month
-        period_start = now - timedelta(days=n_periods * 30)
+    else:  # month — align to first day of month so each bucket is a full calendar month
+        today = now.date()
+        month = today.month - n_periods
+        year  = today.year
+        while month <= 0:
+            month += 12
+            year  -= 1
+        period_start = datetime(year, month, 1, tzinfo=timezone.utc)
 
     db: Session = SessionLocal()
     try:

--- a/src/V_APP/Data_Module/application/queries/sustainability_queries.py
+++ b/src/V_APP/Data_Module/application/queries/sustainability_queries.py
@@ -120,6 +120,7 @@ def get_sustainability_summary(
         if trucks_processed == 0:
             return {
                 "avg_waiting_minutes": 0.0,
+                "total_waiting_minutes": 0.0,
                 "total_co2_kg_estimate": 0.0,
                 "trucks_delayed": 0,
                 "trucks_processed": 0,
@@ -151,6 +152,7 @@ def get_sustainability_summary(
 
         return {
             "avg_waiting_minutes": avg_waiting,
+            "total_waiting_minutes": round(total_waiting, 1),
             "total_co2_kg_estimate": total_co2,
             "trucks_delayed": delayed,
             "trucks_processed": trucks_processed,
@@ -165,6 +167,7 @@ def get_sustainability_summary(
         logger.exception("get_sustainability_summary failed")
         return {
             "avg_waiting_minutes": 0.0,
+            "total_waiting_minutes": 0.0,
             "total_co2_kg_estimate": 0.0,
             "trucks_delayed": 0,
             "trucks_processed": 0,

--- a/src/V_APP/Data_Module/application/queries/worker_queries.py
+++ b/src/V_APP/Data_Module/application/queries/worker_queries.py
@@ -210,8 +210,9 @@ def get_operator_gate_dashboard(
                 for a in upcoming_rows
             ],
             "stats": {
+                "scheduled": stats_dict.get("scheduled", 0),
                 "in_transit": stats_dict.get("in_transit", 0),
-                "delayed": stats_dict.get("delayed", 0),
+                "in_process": stats_dict.get("in_process", 0),
                 "completed": stats_dict.get("completed", 0),
                 "canceled": stats_dict.get("canceled", 0),
             },

--- a/src/V_APP/Data_Module/application/schemas.py
+++ b/src/V_APP/Data_Module/application/schemas.py
@@ -358,6 +358,10 @@ class Appointment(AppointmentBase):
     terminal: Optional[Terminal] = None
     gate_in: Optional[Gate] = None
     gate_out: Optional[Gate] = None
+    # Infraction review fields (nullable — set by manager PATCH /arrivals/{id}/review)
+    reviewed_at: Optional[datetime] = None
+    reviewed_by: Optional[str] = None
+    review_note: Optional[str] = None
     # Orthogonal sub-state fields (populated by model_validator from ORM properties)
     display_status: Optional[str] = None
     primary_status: Optional[str] = None
@@ -399,6 +403,20 @@ class Appointment(AppointmentBase):
         else:
             self.display_status = raw
 
+        return self
+
+
+# ==========================
+# MANAGER VIEW — driver fields always redacted (RGPD)
+# ==========================
+
+class AppointmentManagerView(Appointment):
+    """Appointment schema for manager-facing endpoints.
+    Driver identity fields are always nullified — managers see the truck, not the person."""
+    @model_validator(mode='after')
+    def _redact_driver(self):
+        self.driver_license = None
+        self.driver = None
         return self
 
 

--- a/src/V_APP/Data_Module/application/schemas.py
+++ b/src/V_APP/Data_Module/application/schemas.py
@@ -13,9 +13,9 @@ DecimalAsFloat = Annotated[Decimal, PlainSerializer(float, return_type=float, wh
 # ==========================
 
 class DeliveryStatusEnum(str, Enum):
-    not_started = "not_started"
+    in_port = "in_port"
     unloading = "unloading"
-    completed = "completed"
+    done = "done"
 
 
 class PhysicalStateEnum(str, Enum):
@@ -40,10 +40,8 @@ class AppointmentStatusEnum(str, Enum):
     scheduled = "scheduled"
     in_transit = "in_transit"
     in_process = "in_process"
-    unloading = "unloading"
-    canceled = "canceled"
-    delayed = "delayed"
     completed = "completed"
+    canceled = "canceled"
 
 
 class TypeAlertEnum(str, Enum):
@@ -365,35 +363,39 @@ class Appointment(AppointmentBase):
     primary_status: Optional[str] = None
     is_delayed: Optional[bool] = None
     is_unloading: Optional[bool] = None
+    is_in_port: Optional[bool] = None
+    is_visit_done: Optional[bool] = None
 
     model_config = {"from_attributes": True}
 
     @model_validator(mode="after")
     def _populate_substates(self) -> "Appointment":
-        """Derive display_status and primary_status from status + sub-state flags.
+        """Derive display_status and primary_status from stored status + sub-state flags.
 
-        is_delayed and is_unloading are auto-populated from ORM @property via from_attributes.
+        Primary flow: scheduled → in_transit → in_process → completed | canceled
+        Sub-states (never stored, derived from ORM @property via from_attributes):
+          - is_delayed:   in_transit past tolerance window
+          - is_in_port:   in_process, Visit.state == 'in_port'
+          - is_unloading: in_process, Visit.state == 'unloading'
         """
         raw = self.status.value if self.status else "scheduled"
         is_del = self.is_delayed or False
-        # Backward compat: legacy rows stored with status='unloading' before Visit sub-state refactor
-        if raw == "unloading" and not self.is_unloading:
-            self.is_unloading = True
         is_unl = self.is_unloading or False
+        is_inp = self.is_in_port or False
+        is_vd  = self.is_visit_done or False
 
-        # primary_status: the real workflow state (never 'delayed'/'unloading')
-        if raw == "delayed":
-            self.primary_status = "in_transit"
-        elif raw == "unloading":
-            self.primary_status = "in_process"
-        else:
-            self.primary_status = raw
+        # primary_status always matches the stored enum value
+        self.primary_status = raw
 
-        # display_status: computed string for UI badges
+        # display_status: most specific sub-state badge for UI
         if raw == "in_transit" and is_del:
             self.display_status = "delayed"
-        elif (raw == "in_process" or raw == "unloading") and is_unl:
+        elif raw == "in_process" and is_vd:
+            self.display_status = "leaving_port"
+        elif raw == "in_process" and is_unl:
             self.display_status = "unloading"
+        elif raw == "in_process" and is_inp:
+            self.display_status = "in_port"
         else:
             self.display_status = raw
 
@@ -411,7 +413,7 @@ class VisitBase(BaseModel):
     shift_date: date
     entry_time: Optional[datetime] = None
     out_time: Optional[datetime] = None
-    state: DeliveryStatusEnum = DeliveryStatusEnum.not_started
+    state: DeliveryStatusEnum = DeliveryStatusEnum.in_port
 
 
 class VisitCreate(VisitBase):

--- a/src/V_APP/Data_Module/application/use_cases/appointment_commands.py
+++ b/src/V_APP/Data_Module/application/use_cases/appointment_commands.py
@@ -334,3 +334,40 @@ def cmd_update_visit_state(
         appointment_id, new_state,
     )
     return visit
+
+
+def cmd_review_infraction(
+    appointment: dict,
+    reviewed_by: str,
+    note: Optional[str] = None,
+) -> dict:
+    """
+    Apply a manager review to a highway infraction appointment.
+
+    Args:
+        appointment: dict with at least {"id", "highway_infraction"}.
+        reviewed_by: num_worker of the reviewing manager.
+        note: optional contact/warning note.
+
+    Returns:
+        Updated appointment dict with review fields set.
+
+    Raises:
+        ValueError: if the appointment has no highway_infraction flag.
+    """
+    if not appointment.get("highway_infraction"):
+        raise ValueError(
+            f"Appointment {appointment.get('id')} has no highway infraction — cannot review."
+        )
+
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    appointment["reviewed_at"] = now
+    appointment["reviewed_by"] = reviewed_by
+    appointment["review_note"] = note.strip() if note and note.strip() else None
+
+    logger.info(
+        "cmd_review_infraction: appointment=%s reviewed_by=%s",
+        appointment.get("id"),
+        reviewed_by,
+    )
+    return appointment

--- a/src/V_APP/Data_Module/application/use_cases/appointment_commands.py
+++ b/src/V_APP/Data_Module/application/use_cases/appointment_commands.py
@@ -195,6 +195,9 @@ def cmd_process_decision(
 # Command: Flag highway infraction
 # ------------------------------------------------------------------
 
+_INFRACTION_ALLOWED_STATUSES = {"in_transit"}
+
+
 def cmd_flag_highway_infraction(
     uow_factory: Callable[..., IUnitOfWork],
     appointment_id: int,
@@ -202,11 +205,20 @@ def cmd_flag_highway_infraction(
     """Flag an appointment as highway infraction via UoW + Outbox.
 
     Returns aggregate dict on success, None if not found.
+    Raises ValueError if the appointment is already inside the port (status not in_transit/scheduled).
     """
     with uow_factory() as uow:
         aggregate = uow.appointment_state.get_for_update(appointment_id)
         if aggregate is None:
             return None
+
+        current_status = aggregate["status"]
+        if current_status not in _INFRACTION_ALLOWED_STATUSES:
+            raise ValueError(
+                f"Highway infraction can only be flagged while the truck is in_transit "
+                f"(current status: {current_status!r}). "
+                "Only trucks on the road approaching the port can receive a highway infraction update."
+            )
 
         # save_state_transition keeps same status but we need to set
         # highway_infraction — extend metadata for this flag

--- a/src/V_APP/Data_Module/infrastructure/persistence/sql_models.py
+++ b/src/V_APP/Data_Module/infrastructure/persistence/sql_models.py
@@ -16,14 +16,13 @@ DELAY_TOLERANCE_MINUTES = 1
 # ENUMS
 # ==========================
 
-delivery_status_enum = SEnum('not_started', 'unloading', 'completed', name='delivery_status')
+delivery_status_enum = SEnum('in_port', 'unloading', 'done', name='delivery_status')
 physical_state_enum = SEnum('liquid', 'solid', 'gaseous', 'hybrid', name='physical_state')
 access_level_enum = SEnum('admin', 'basic', name='access_level')
 operational_status_enum = SEnum('maintenance', 'operational', 'closed', name='operational_status')
-# 'unloading' and 'delayed' kept for backward compat with existing rows — never written by app code.
-# Primary flow states: scheduled → in_transit → in_process → completed | canceled
-# Sub-states: delayed (computed from time), unloading (derived from Visit.state)
-appointment_status_enum = SEnum('scheduled', 'in_transit', 'in_process', 'unloading', 'canceled', 'delayed', 'completed', name='appointment_status')
+# Primary flow: scheduled → in_transit → in_process → completed | canceled
+# Sub-states (never stored, always computed): delayed (time-based), unloading (from Visit.state)
+appointment_status_enum = SEnum('scheduled', 'in_transit', 'in_process', 'completed', 'canceled', name='appointment_status')
 type_alert_enum = SEnum('generic', 'safety', 'problem', 'operational', name='type_alert')
 direction_enum = SEnum('inbound', 'outbound', name='direction')
 
@@ -303,9 +302,23 @@ class Appointment(Base):
 
     @property
     def is_unloading(self) -> bool:
-        """True when there is an active Visit in unloading state (out_time not yet set)."""
+        """True when there is an active Visit in unloading state."""
         if self.visit:
-            return self.visit.state == 'unloading' and self.visit.out_time is None
+            return self.visit.state == 'unloading'
+        return False
+
+    @property
+    def is_in_port(self) -> bool:
+        """True when truck is inside the port (Visit in in_port state)."""
+        if self.visit:
+            return self.visit.state == 'in_port'
+        return False
+
+    @property
+    def is_visit_done(self) -> bool:
+        """True when unloading is complete but driver hasn't confirmed departure yet (Visit.state == 'done')."""
+        if self.visit:
+            return self.visit.state == 'done'
         return False
 
     @property
@@ -317,17 +330,22 @@ class Appointment(Base):
         Sub-states (never stored, always computed):
           - 'delayed'   — in_transit past scheduled_start_time + DELAY_TOLERANCE_MINUTES
           - 'unloading' — in_process with an active Visit in unloading state
+          - 'in_port'   — in_process with truck inside port but not yet unloading
         """
-        if self.status in ('completed', 'canceled', 'scheduled'):
+        if self.status in ('completed', 'canceled'):
             return self.status
 
         if self.status == 'in_process':
+            if self.is_visit_done:
+                return 'leaving_port'
             if self.is_unloading:
                 return 'unloading'
+            if self.is_in_port:
+                return 'in_port'
             return 'in_process'
 
-        # in_transit: check for delay
-        if self.scheduled_start_time:
+        # scheduled and in_transit: check for delay
+        if self.status in ('scheduled', 'in_transit') and self.scheduled_start_time:
             delay_threshold = self.scheduled_start_time + timedelta(minutes=DELAY_TOLERANCE_MINUTES)
             if datetime.now(timezone.utc).replace(tzinfo=None) > delay_threshold:
                 return 'delayed'
@@ -336,8 +354,14 @@ class Appointment(Base):
 
     @property
     def is_delayed(self) -> bool:
-        """Quick check if appointment is currently delayed."""
-        return self.computed_status == 'delayed'
+        """True when past scheduled_start_time + tolerance and still not in a terminal state.
+        Applies to both 'scheduled' (truck never left) and 'in_transit' (truck on the road)."""
+        if self.status not in ('scheduled', 'in_transit'):
+            return False
+        if not self.scheduled_start_time:
+            return False
+        delay_threshold = self.scheduled_start_time + timedelta(minutes=DELAY_TOLERANCE_MINUTES)
+        return datetime.now(timezone.utc).replace(tzinfo=None) > delay_threshold
     
     @property
     def delay_minutes(self) -> int:
@@ -381,7 +405,7 @@ class Visit(Base):
     out_time = Column(TIMESTAMP)
     
     # Status
-    state = Column(delivery_status_enum, default='unloading')
+    state = Column(delivery_status_enum, default='in_port')
     
     # Relationships
     appointment = relationship("Appointment", back_populates="visit")

--- a/src/V_APP/Data_Module/infrastructure/persistence/sql_models.py
+++ b/src/V_APP/Data_Module/infrastructure/persistence/sql_models.py
@@ -267,7 +267,7 @@ class Appointment(Base):
     
     # Foreign Keys
     booking_reference = Column(String(50), ForeignKey('booking.reference'), nullable=False)
-    driver_license = Column(String(50), ForeignKey('driver.drivers_license'), nullable=False)
+    driver_license = Column(String(50), ForeignKey('driver.drivers_license'), nullable=True)
     truck_license_plate = Column(String(20), ForeignKey('truck.license_plate'), nullable=False)
     terminal_id = Column(Integer, ForeignKey('terminal.id'), nullable=False)
     gate_in_id = Column(Integer, ForeignKey('gate.id'))
@@ -282,7 +282,12 @@ class Appointment(Base):
     version = Column(Integer, nullable=False, default=1, server_default="1")  # Optimistic concurrency control
     notes = Column(Text)
     highway_infraction = Column(Boolean, default=False, server_default="false")  # Hazmat truck on restricted highway route
-    
+
+    # Infraction review (manager acknowledgement)
+    reviewed_at  = Column(TIMESTAMP, nullable=True)
+    reviewed_by  = Column(String(50), nullable=True)   # num_worker of reviewing manager
+    review_note  = Column(Text, nullable=True)
+
     # Relationships
     booking = relationship("Booking", back_populates="appointments")
     driver = relationship("Driver", back_populates="appointments")

--- a/src/V_APP/Data_Module/infrastructure/persistence/visit_repository.py
+++ b/src/V_APP/Data_Module/infrastructure/persistence/visit_repository.py
@@ -62,7 +62,7 @@ class SqlAlchemyVisitRepository(IVisitRepository):
             shift_type=shift_type,
             shift_date=shift_date,
             entry_time=entry_time or datetime.now(timezone.utc).replace(tzinfo=None),
-            state="not_started",
+            state="in_port",
         )
         self._session.add(visit)
         self._session.flush()
@@ -108,7 +108,7 @@ class SqlAlchemyVisitRepository(IVisitRepository):
         visit.state = new_state
         if out_time:
             visit.out_time = out_time
-        elif new_state == "completed":
+        elif new_state == "done":
             visit.out_time = datetime.now(timezone.utc).replace(tzinfo=None)
         self._session.flush()
         return self._to_dict(visit)

--- a/src/V_APP/Data_Module/requirements.txt
+++ b/src/V_APP/Data_Module/requirements.txt
@@ -1,6 +1,7 @@
 # --- Web & API ---
 fastapi
 uvicorn[standard]
+python-multipart
 pydantic
 pydantic-settings
 

--- a/src/V_APP/Data_Module/routes/arrivals.py
+++ b/src/V_APP/Data_Module/routes/arrivals.py
@@ -6,7 +6,7 @@ Reads directly from PostgreSQL (source of truth) with Redis caching.
 """
 
 from typing import Annotated, List, Optional, Dict, Any, Generic, TypeVar
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timezone, timedelta
 import csv, io, uuid
 from fastapi import APIRouter, Depends, File, HTTPException, Query, Path, UploadFile
 from sqlalchemy.orm import Session, selectinload, joinedload
@@ -463,6 +463,8 @@ def create_visit(
 
 # Only truck_license_plate and terminal_name are required — booking_reference is auto-generated.
 _BULK_REQUIRED_COLS = {"truck_license_plate", "terminal_name"}
+_VALID_DIRECTIONS = {"inbound", "outbound"}
+_VALID_CARGO_STATES = {"liquid", "solid", "gaseous", "hybrid"}
 
 
 @router.post(
@@ -480,7 +482,10 @@ def bulk_import_arrivals(
     drivers associate later via POST /drivers/claim with the arrival_id PIN.
 
     Required columns: truck_license_plate, terminal_name
-    Optional columns: scheduled_start_time (ISO-8601), expected_duration (minutes), notes
+    Optional columns:
+      scheduled_start_time (ISO-8601), expected_duration (minutes), notes,
+      direction (inbound|outbound, default: inbound),
+      cargo_description, cargo_type (liquid|solid|gaseous|hybrid), cargo_quantity (decimal)
 
     Booking references are auto-generated (CSV-XXXXXXXX format).
     Terminals are looked up by name (case-insensitive).
@@ -542,13 +547,60 @@ def bulk_import_arrivals(
             skipped += 1
             continue
 
-        # Auto-generate a unique booking reference
-        booking_ref = f"CSV-{uuid.uuid4().hex[:8].upper()}"
-        booking = BookingORM(reference=booking_ref, direction=None)
-        db.add(booking)
-        db.flush()  # ensure the booking FK is available before the appointment
+        # Conflict check: reject if truck already has an active appointment within ±4 h of the given time
+        # (or any active appointment today if no time provided)
+        _active_statuses = ('scheduled', 'in_transit', 'in_process')
+        raw_time_for_conflict = row.get("scheduled_start_time", "")
+        if raw_time_for_conflict:
+            try:
+                ref_time = datetime.fromisoformat(raw_time_for_conflict)
+                window_start = ref_time - timedelta(hours=4)
+                window_end   = ref_time + timedelta(hours=4)
+                conflict = (
+                    db.query(AppointmentORM)
+                    .filter(
+                        AppointmentORM.truck_license_plate == plate,
+                        AppointmentORM.status.in_(_active_statuses),
+                        AppointmentORM.scheduled_start_time >= window_start,
+                        AppointmentORM.scheduled_start_time <= window_end,
+                    )
+                    .first()
+                )
+                if conflict:
+                    conflict_time = conflict.scheduled_start_time.strftime("%Y-%m-%d %H:%M") if conflict.scheduled_start_time else "unknown time"
+                    errors.append({"row": row_num, "reason": f"Truck {plate!r} already has an active appointment at {conflict_time} (status: {conflict.status}) — within 4 h window"})
+                    skipped += 1
+                    continue
+            except ValueError:
+                pass  # invalid time format caught later in the parsing block
+        else:
+            # No time given: check for any active appointment today
+            today_start = datetime.combine(date.today(), datetime.min.time())
+            today_end   = datetime.combine(date.today(), datetime.max.time())
+            conflict = (
+                db.query(AppointmentORM)
+                .filter(
+                    AppointmentORM.truck_license_plate == plate,
+                    AppointmentORM.status.in_(_active_statuses),
+                    AppointmentORM.scheduled_start_time >= today_start,
+                    AppointmentORM.scheduled_start_time <= today_end,
+                )
+                .first()
+            )
+            if conflict:
+                conflict_time = conflict.scheduled_start_time.strftime("%H:%M") if conflict.scheduled_start_time else "unknown time"
+                errors.append({"row": row_num, "reason": f"Truck {plate!r} already has an active appointment today at {conflict_time} (status: {conflict.status})"})
+                skipped += 1
+                continue
 
-        # Parse optional fields
+        # direction (optional, default inbound)
+        raw_dir = row.get("direction", "").lower() or "inbound"
+        if raw_dir not in _VALID_DIRECTIONS:
+            errors.append({"row": row_num, "reason": f"direction must be 'inbound' or 'outbound', got {raw_dir!r}"})
+            skipped += 1
+            continue
+
+        # scheduled_start_time (optional)
         scheduled_start = None
         raw_time = row.get("scheduled_start_time", "")
         if raw_time:
@@ -559,6 +611,7 @@ def bulk_import_arrivals(
                 skipped += 1
                 continue
 
+        # expected_duration (optional, integer minutes)
         expected_dur = None
         raw_dur = row.get("expected_duration", "")
         if raw_dur:
@@ -568,6 +621,42 @@ def bulk_import_arrivals(
                 errors.append({"row": row_num, "reason": f"expected_duration must be integer minutes, got {raw_dur!r}"})
                 skipped += 1
                 continue
+
+        # cargo_quantity (optional, decimal)
+        cargo_qty = None
+        raw_qty = row.get("cargo_quantity", "")
+        if raw_qty:
+            try:
+                cargo_qty = float(raw_qty)
+            except ValueError:
+                errors.append({"row": row_num, "reason": f"cargo_quantity must be a number, got {raw_qty!r}"})
+                skipped += 1
+                continue
+
+        # cargo_type validation (optional)
+        cargo_type = row.get("cargo_type", "").lower() or None
+        if cargo_type and cargo_type not in _VALID_CARGO_STATES:
+            errors.append({"row": row_num, "reason": f"cargo_type must be one of {sorted(_VALID_CARGO_STATES)}, got {cargo_type!r}"})
+            skipped += 1
+            continue
+
+        # Auto-generate a unique booking reference
+        booking_ref = f"CSV-{uuid.uuid4().hex[:8].upper()}"
+        booking = BookingORM(reference=booking_ref, direction=raw_dir)
+        db.add(booking)
+        db.flush()  # ensure the booking FK is available before appointment and cargo
+
+        # Create cargo row if any cargo field is provided
+        cargo_description = row.get("cargo_description") or None
+        if cargo_description or cargo_type or cargo_qty is not None:
+            from infrastructure.persistence.sql_models import Cargo as CargoORM
+            cargo_row = CargoORM(
+                booking_reference=booking_ref,
+                description=cargo_description,
+                state=cargo_type or "solid",
+                quantity=cargo_qty if cargo_qty is not None else 0,
+            )
+            db.add(cargo_row)
 
         appt = AppointmentORM(
             booking_reference=booking_ref,

--- a/src/V_APP/Data_Module/routes/arrivals.py
+++ b/src/V_APP/Data_Module/routes/arrivals.py
@@ -6,14 +6,15 @@ Reads directly from PostgreSQL (source of truth) with Redis caching.
 """
 
 from typing import Annotated, List, Optional, Dict, Any, Generic, TypeVar
-from datetime import date
-from fastapi import APIRouter, Depends, HTTPException, Query, Path
+from datetime import date, datetime, timezone
+import csv, io, uuid
+from fastapi import APIRouter, Depends, File, HTTPException, Query, Path, UploadFile
 from sqlalchemy.orm import Session, selectinload, joinedload
 from pydantic import BaseModel
 from loguru import logger
 
 from application.schemas import (
-    Appointment, AppointmentStatusUpdate, Visit, VisitStatusUpdate, ShiftTypeEnum
+    Appointment, AppointmentManagerView, AppointmentStatusUpdate, Visit, VisitStatusUpdate, ShiftTypeEnum
 )
 from application.queries.arrival_queries import (
     get_all_appointments,
@@ -35,11 +36,12 @@ from application.use_cases.appointment_commands import (
     cmd_flag_highway_infraction,
     cmd_create_visit,
     cmd_update_visit_state,
+    cmd_review_infraction,
 )
 from application.queries.cache_queries import get_or_cache
 from application.queries.arrival_queries import _APPOINTMENT_EAGER_LOADS
 from infrastructure.persistence.redis import get_cached_appointment, cache_appointment
-from infrastructure.persistence.sql_models import Visit as VisitORM, Shift as ShiftORM, Operator, Manager
+from infrastructure.persistence.sql_models import Visit as VisitORM, Shift as ShiftORM, Operator, Manager, Appointment as AppointmentORM
 
 T = TypeVar("T")
 
@@ -98,7 +100,7 @@ class CreateVisitRequest(BaseModel):
 
 # ==================== GET ENDPOINTS ====================
 
-@router.get("", response_model=PaginatedResponse[Appointment], responses={400: {"description": "Invalid shift type"}})
+@router.get("", response_model=PaginatedResponse[AppointmentManagerView], responses={400: {"description": "Invalid shift type"}})
 def list_arrivals(
     page: Annotated[int, Query(ge=1, description="Page number (1-based)")] = 1,
     limit: Annotated[int, Query(ge=1, le=100, description="Items per page")] = 20,
@@ -326,6 +328,57 @@ def flag_highway_infraction(
     return Appointment.model_validate(appointment)
 
 
+class InfractionReviewRequest(BaseModel):
+    note: Optional[str] = None
+    reviewed_by: str  # num_worker of the reviewing manager
+
+
+@router.patch(
+    "/{appointment_id}/review",
+    status_code=200,
+    responses={
+        404: {"description": "Appointment not found"},
+        409: {"description": "Appointment has no highway infraction"},
+    },
+)
+def review_infraction(
+    appointment_id: Annotated[int, Path(description="Appointment ID")],
+    body: InfractionReviewRequest,
+    db: Annotated[Session, Depends(get_db)] = None,
+):
+    """
+    Mark a highway infraction as reviewed by a manager.
+    Records reviewed_at (UTC), reviewed_by (num_worker), and an optional note.
+    Idempotent — re-reviewing overwrites the previous review record.
+    """
+    appt = db.query(AppointmentORM).filter(AppointmentORM.id == appointment_id).first()
+    if not appt:
+        raise HTTPException(status_code=404, detail="Appointment not found")
+    if not appt.highway_infraction:
+        raise HTTPException(status_code=409, detail="Appointment has no highway infraction")
+
+    aggregate = {
+        "id": appt.id,
+        "highway_infraction": appt.highway_infraction,
+    }
+    try:
+        updated = cmd_review_infraction(aggregate, body.reviewed_by, body.note)
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
+
+    appt.reviewed_at = updated["reviewed_at"]
+    appt.reviewed_by = updated["reviewed_by"]
+    appt.review_note = updated["review_note"]
+    db.commit()
+
+    return {
+        "id": appt.id,
+        "reviewed_at": appt.reviewed_at.isoformat() if appt.reviewed_at else None,
+        "reviewed_by": appt.reviewed_by,
+        "review_note": appt.review_note,
+    }
+
+
 # ==================== UPDATE ENDPOINTS ====================
 
 @router.patch("/{appointment_id}/status", response_model=Appointment, responses={404: {"description": "Appointment not found"}})
@@ -404,6 +457,134 @@ def create_visit(
     if result is None:
         raise HTTPException(status_code=404, detail="Appointment not found or visit already exists")
     return Visit.model_validate(_load_visit(db, appointment_id))
+
+
+# ==================== CSV BULK IMPORT ====================
+
+# Only truck_license_plate and terminal_name are required — booking_reference is auto-generated.
+_BULK_REQUIRED_COLS = {"truck_license_plate", "terminal_name"}
+
+
+@router.post(
+    "/bulk",
+    status_code=201,
+    summary="Bulk-import appointments from CSV (no driver — RGPD flow)",
+    responses={400: {"description": "Invalid or empty CSV"}},
+)
+def bulk_import_arrivals(
+    file: UploadFile = File(...),
+    db: Annotated[Session, Depends(get_db)] = None,
+):
+    """
+    Import appointments from a CSV file.  Driver is NOT included in the CSV;
+    drivers associate later via POST /drivers/claim with the arrival_id PIN.
+
+    Required columns: truck_license_plate, terminal_name
+    Optional columns: scheduled_start_time (ISO-8601), expected_duration (minutes), notes
+
+    Booking references are auto-generated (CSV-XXXXXXXX format).
+    Terminals are looked up by name (case-insensitive).
+
+    Returns: { created, skipped, errors: [{row, reason}] }
+    """
+    content = file.file.read()
+    try:
+        text = content.decode("utf-8-sig")
+    except UnicodeDecodeError:
+        raise HTTPException(status_code=400, detail="File must be UTF-8 encoded")
+
+    reader = csv.DictReader(io.StringIO(text))
+    if reader.fieldnames is None:
+        raise HTTPException(status_code=400, detail="Empty or unreadable CSV")
+
+    headers = {h.strip().lower() for h in reader.fieldnames}
+    missing = _BULK_REQUIRED_COLS - headers
+    if missing:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Missing required columns: {', '.join(sorted(missing))}",
+        )
+
+    from infrastructure.persistence.sql_models import (
+        Appointment as AppointmentORM,
+        Booking as BookingORM,
+        Truck as TruckORM,
+        Terminal as TerminalORM,
+    )
+    from sqlalchemy import func as sql_func
+
+    created = skipped = 0
+    errors: List[Dict[str, Any]] = []
+
+    for row_num, raw in enumerate(reader, start=2):
+        row = {k.strip().lower(): (v or "").strip() for k, v in raw.items()}
+
+        plate = row.get("truck_license_plate", "")
+        terminal_name = row.get("terminal_name", "")
+
+        if not plate or not terminal_name:
+            errors.append({"row": row_num, "reason": "Missing required field (truck_license_plate or terminal_name)"})
+            skipped += 1
+            continue
+
+        # Resolve terminal by name (case-insensitive)
+        terminal = db.query(TerminalORM).filter(
+            sql_func.lower(TerminalORM.name) == terminal_name.lower()
+        ).first()
+        if not terminal:
+            errors.append({"row": row_num, "reason": f"Terminal {terminal_name!r} not found"})
+            skipped += 1
+            continue
+
+        # Validate truck
+        if not db.query(TruckORM).filter(TruckORM.license_plate == plate).first():
+            errors.append({"row": row_num, "reason": f"Truck {plate!r} not registered in the system"})
+            skipped += 1
+            continue
+
+        # Auto-generate a unique booking reference
+        booking_ref = f"CSV-{uuid.uuid4().hex[:8].upper()}"
+        booking = BookingORM(reference=booking_ref, direction=None)
+        db.add(booking)
+        db.flush()  # ensure the booking FK is available before the appointment
+
+        # Parse optional fields
+        scheduled_start = None
+        raw_time = row.get("scheduled_start_time", "")
+        if raw_time:
+            try:
+                scheduled_start = datetime.fromisoformat(raw_time)
+            except ValueError:
+                errors.append({"row": row_num, "reason": f"Invalid scheduled_start_time: {raw_time!r} (expected ISO-8601)"})
+                skipped += 1
+                continue
+
+        expected_dur = None
+        raw_dur = row.get("expected_duration", "")
+        if raw_dur:
+            try:
+                expected_dur = int(raw_dur)
+            except ValueError:
+                errors.append({"row": row_num, "reason": f"expected_duration must be integer minutes, got {raw_dur!r}"})
+                skipped += 1
+                continue
+
+        appt = AppointmentORM(
+            booking_reference=booking_ref,
+            driver_license=None,
+            truck_license_plate=plate,
+            terminal_id=terminal.id,
+            scheduled_start_time=scheduled_start,
+            expected_duration=expected_dur,
+            notes=row.get("notes") or None,
+            highway_infraction=False,
+            status="scheduled",
+        )
+        db.add(appt)
+        created += 1
+
+    db.commit()
+    return {"created": created, "skipped": skipped, "errors": errors}
 
 
 @router.patch("/{appointment_id}/visit", response_model=Visit, responses={404: {"description": "Visit not found"}})

--- a/src/V_APP/Data_Module/routes/arrivals.py
+++ b/src/V_APP/Data_Module/routes/arrivals.py
@@ -306,16 +306,20 @@ def query_arrivals_by_license_plate(
 
 # ==================== HIGHWAY INFRACTION ====================
 
-@router.patch("/{appointment_id}/highway-infraction", response_model=Appointment, responses={404: {"description": "Appointment not found"}})
+@router.patch("/{appointment_id}/highway-infraction", response_model=Appointment, responses={404: {"description": "Appointment not found"}, 409: {"description": "Truck already inside port — infraction not applicable"}})
 def flag_highway_infraction(
     appointment_id: Annotated[int, Path(description="Appointment ID")],
     db: Annotated[Session, Depends(get_db)] = None,
 ):
     """
     Flag an appointment as highway infraction.
-    Hazmat truck detected on restricted highway route before port entry.
+    Only allowed while the truck is in transit (scheduled or in_transit status).
+    A truck already inside the port (in_process, completed) cannot receive this flag.
     """
-    result = cmd_flag_highway_infraction(_uow_factory, appointment_id)
+    try:
+        result = cmd_flag_highway_infraction(_uow_factory, appointment_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
     if result is None:
         raise HTTPException(status_code=404, detail="Appointment not found")
     appointment = get_appointment_by_id(db, appointment_id)

--- a/src/V_APP/Data_Module/routes/decisions.py
+++ b/src/V_APP/Data_Module/routes/decisions.py
@@ -270,7 +270,7 @@ def manual_review(
 
     When approved:
     - Updates Appointment.status to 'in_process' (confirmed arrival)
-    - Creates Visit with state='not_started' if gate_id provided
+    - Creates Visit with state='in_port' if gate_id provided
 
     When rejected:
     - Updates Appointment.status to 'canceled'

--- a/src/V_APP/Data_Module/routes/driver.py
+++ b/src/V_APP/Data_Module/routes/driver.py
@@ -14,7 +14,7 @@ Future: OAuth 2.0 + JWT
 CQRS: GET endpoints read from MongoDB. POST (auth/claim) use UoW.
 """
 
-from typing import Annotated, List, Optional
+from typing import Annotated, Dict, List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, Path
 
 from application.schemas import (
@@ -33,6 +33,7 @@ from application.queries.driver_queries import (
     get_driver_active_appointment,
     get_driver_today_appointments,
     get_driver_appointments,
+    get_available_bookings_for_driver,
 )
 from infrastructure.persistence.unit_of_work import SqlAlchemyUnitOfWork
 from infrastructure.persistence.postgres import SessionLocal
@@ -146,6 +147,23 @@ def get_my_today_arrivals(
 ):
     """Gets today's appointments for the authenticated driver."""
     return get_driver_today_appointments(claims["sub"])
+
+
+@router.get("/me/available-bookings", response_model=Dict)
+def get_available_bookings(
+    claims: Annotated[dict, Depends(_driver_claims)],
+    page: Annotated[int, Query(ge=1)] = 1,
+    limit: Annotated[int, Query(ge=1, le=50)] = 20,
+):
+    """
+    Returns unclaimed scheduled appointments for trucks belonging to the driver's company.
+    Used by the driver app 'Available Bookings' screen.
+    Driver claims one via POST /drivers/claim with the arrival_id PIN.
+    """
+    driver = get_driver_by_license(claims["sub"])
+    if not driver or not driver.get("company_nif"):
+        return {"items": [], "total": 0, "page": page, "limit": limit, "pages": 1}
+    return get_available_bookings_for_driver(driver["company_nif"], page=page, limit=limit)
 
 
 @router.get("/me/history", response_model=List[Appointment])

--- a/src/V_APP/Data_Module/routes/statistics.py
+++ b/src/V_APP/Data_Module/routes/statistics.py
@@ -24,6 +24,10 @@ from application.queries.manager_statistics_queries import (
     get_alerts_breakdown,
     get_decision_analytics,
 )
+from application.queries.sustainability_queries import (
+    get_sustainability_summary,
+    get_sustainability_trend,
+)
 
 router = APIRouter(prefix="/statistics", tags=["Statistics & Analytics"])
 
@@ -471,3 +475,32 @@ def dashboard_summary(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to generate dashboard summary: {str(e)}"
         )
+
+
+# ==================== SUSTAINABILITY (manager only) ====================
+
+@router.get("/sustainability/summary")
+def sustainability_summary(
+    from_date: Annotated[Optional[str], Query(description="Start date YYYY-MM-DD (default: start of current week)")] = None,
+    to_date: Annotated[Optional[str], Query(description="End date YYYY-MM-DD (default: today)")] = None,
+):
+    """
+    CO₂ and waiting-time KPIs for a date range.
+
+    **Methodology:** ICCT HDV Roadmap 2023 + EU JRC — 0.84 kg CO₂/h idling (Euro VI).
+    Waiting time = MAX(0, entry_time − scheduled_start_time).
+    Appointments without scheduled_start_time are excluded and reported in `appointments_excluded`.
+    """
+    return get_sustainability_summary(from_date, to_date)
+
+
+@router.get("/sustainability/trend")
+def sustainability_trend(
+    granularity: Annotated[str, Query(description="'day' | 'week' | 'month'")] = "day",
+    n: Annotated[int, Query(description="Number of past periods to return (max 52)", ge=1, le=52)] = 12,
+):
+    """
+    Time-series of CO₂ estimates and avg waiting times for the chart.
+    Returns the last `n` complete periods at the requested granularity.
+    """
+    return get_sustainability_trend(granularity, n)

--- a/src/V_APP/Data_Module/routes/worker.py
+++ b/src/V_APP/Data_Module/routes/worker.py
@@ -277,13 +277,14 @@ def list_operators(
 
 @router.get("/operators/me", response_model=Dict[str, Any], responses={404: {"description": "Operator not found"}})
 def get_my_operator_info(
-    num_worker: Annotated[str, Query(description="Operator num_worker (from JWT)")],
+    email: Annotated[str, Query(description="Worker email from JWT sub claim")],
 ):
-    """
-    Gets authenticated operator information.
-    In production: num_worker would come from JWT.
-    """
-    info = get_operator_info(num_worker)
+    """Gets authenticated operator information by email (resolved from JWT by the gateway)."""
+    with _uow_factory() as uow:
+        worker = uow.workers.get_by_email_active(email)
+    if not worker:
+        raise HTTPException(status_code=404, detail="Operator not found")
+    info = get_operator_info(worker["num_worker"])
     if not info:
         raise HTTPException(status_code=404, detail="Operator not found")
     return info
@@ -399,13 +400,14 @@ def list_managers(
 
 @router.get("/managers/me", response_model=Dict[str, Any], responses={404: {"description": "Manager not found"}})
 def get_my_manager_info(
-    num_worker: Annotated[str, Query(description="Manager num_worker (from JWT)")],
+    email: Annotated[str, Query(description="Worker email from JWT sub claim")],
 ):
-    """
-    Gets authenticated manager information.
-    In production: num_worker would come from JWT.
-    """
-    info = get_manager_info(num_worker)
+    """Gets authenticated manager information by email (resolved from JWT by the gateway)."""
+    with _uow_factory() as uow:
+        worker = uow.workers.get_by_email_active(email)
+    if not worker:
+        raise HTTPException(status_code=404, detail="Manager not found")
+    info = get_manager_info(worker["num_worker"])
     if not info:
         raise HTTPException(status_code=404, detail="Manager not found")
     return info

--- a/src/V_APP/Data_Module/routes/worker.py
+++ b/src/V_APP/Data_Module/routes/worker.py
@@ -35,10 +35,10 @@ from application.queries.worker_queries import (
 from infrastructure.persistence.unit_of_work import SqlAlchemyUnitOfWork
 from infrastructure.persistence.postgres import get_db, SessionLocal
 from sqlalchemy import func as sa_func
-from infrastructure.persistence.sql_models import Shift as ShiftORM, Visit as VisitORM, Operator, Manager
+from infrastructure.persistence.sql_models import Shift as ShiftORM, Visit as VisitORM, Operator, Manager, Gate as GateORM
 from utils.auth_token import generate_internal_jwt, require_role
 from infrastructure.persistence.redis import set_session
-from utils.shift_utils import current_shift_type
+from utils.shift_utils import current_shift_type, parse_shift_type
 from config import settings
 
 router = APIRouter(prefix="/workers", tags=["Workers"])
@@ -96,6 +96,19 @@ class ManagerOverview(BaseModel):
     shifts_today: int
     recent_alerts: int
     statistics: Dict[str, int]
+
+
+class ShiftCreateRequest(BaseModel):
+    gate_id: int
+    shift_type: str  # MORNING | AFTERNOON | NIGHT
+    date: date
+    operator_num_worker: Optional[str] = None
+    manager_num_worker: Optional[str] = None
+
+
+class ShiftUpdateRequest(BaseModel):
+    operator_num_worker: Optional[str] = None
+    manager_num_worker: Optional[str] = None
 
 
 # ==================== AUTH ENDPOINTS ====================
@@ -252,6 +265,188 @@ def _shift_before(a, b) -> bool:
     """Return True if shift type `a` is earlier in the day than `b`."""
     order = {"MORNING": 0, "AFTERNOON": 1, "NIGHT": 2}
     return order.get(a.name, 0) < order.get(b.name, 0)
+
+
+# ==================== GATES LISTING ====================
+
+@router.get("/gates", response_model=List[Dict[str, Any]])
+def list_gates(db: Annotated[Session, Depends(get_db)]):
+    """Lists all active gates. Used by shift creation modals."""
+    gates = db.query(GateORM).filter(GateORM.estado == "Ativo").order_by(GateORM.id).all()
+    return [{"id": g.id, "label": g.label} for g in gates]
+
+
+# ==================== SHIFT CRUD ====================
+
+@router.post("/shifts", response_model=Dict[str, Any], status_code=status.HTTP_201_CREATED)
+def create_shift(
+    body: ShiftCreateRequest,
+    db: Annotated[Session, Depends(get_db)],
+):
+    """
+    Creates a new shift. Validates:
+    - Gate exists and is active.
+    - No existing shift for (gate_id, shift_type, date).
+    - Operator not already assigned to any shift on the same date.
+    """
+    try:
+        parsed_type = parse_shift_type(body.shift_type)
+    except ValueError:
+        raise HTTPException(status_code=400, detail=f"Invalid shift_type: {body.shift_type}")
+
+    gate = db.query(GateORM).filter(GateORM.id == body.gate_id, GateORM.estado == "Ativo").first()
+    if not gate:
+        raise HTTPException(status_code=404, detail=f"Gate {body.gate_id} not found or inactive")
+
+    existing = db.query(ShiftORM).filter(
+        ShiftORM.gate_id == body.gate_id,
+        ShiftORM.shift_type == parsed_type,
+        ShiftORM.date == body.date,
+    ).first()
+    if existing:
+        raise HTTPException(status_code=409, detail="Shift already exists for this gate/type/date")
+
+    if body.operator_num_worker:
+        conflict = db.query(ShiftORM).filter(
+            ShiftORM.date == body.date,
+            ShiftORM.operator_num_worker == body.operator_num_worker,
+        ).first()
+        if conflict:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Operator {body.operator_num_worker} already assigned to a shift on {body.date}",
+            )
+
+    shift = ShiftORM(
+        gate_id=body.gate_id,
+        shift_type=parsed_type,
+        date=body.date,
+        operator_num_worker=body.operator_num_worker or None,
+        manager_num_worker=body.manager_num_worker or None,
+    )
+    db.add(shift)
+    db.commit()
+    db.refresh(shift)
+
+    db.expire_all()
+    shift = db.query(ShiftORM).options(
+        joinedload(ShiftORM.gate),
+        joinedload(ShiftORM.operator).joinedload(Operator.worker),
+    ).filter(
+        ShiftORM.gate_id == body.gate_id,
+        ShiftORM.shift_type == parsed_type,
+        ShiftORM.date == body.date,
+    ).first()
+
+    return {
+        "id": f"{shift.gate_id}-{shift.shift_type.name}-{shift.date.isoformat()}",
+        "gateId": shift.gate_id,
+        "gateName": shift.gate.label if shift.gate else f"Gate {shift.gate_id}",
+        "shiftType": shift.shift_type.name,
+        "date": shift.date.isoformat(),
+        "operatorId": shift.operator_num_worker or "",
+        "operatorName": shift.operator.worker.name if shift.operator and shift.operator.worker else "",
+        "managerId": shift.manager_num_worker or "",
+        "status": "pending",
+    }
+
+
+@router.put("/shifts/{gate_id}/{shift_type}/{shift_date}", response_model=Dict[str, Any])
+def update_shift(
+    gate_id: Annotated[int, Path()],
+    shift_type: Annotated[str, Path()],
+    shift_date: Annotated[date, Path()],
+    body: ShiftUpdateRequest,
+    db: Annotated[Session, Depends(get_db)],
+):
+    """
+    Updates operator/manager assignment for an existing shift.
+    Validates operator not already assigned elsewhere on the same date.
+    """
+    try:
+        parsed_type = parse_shift_type(shift_type)
+    except ValueError:
+        raise HTTPException(status_code=400, detail=f"Invalid shift_type: {shift_type}")
+
+    shift = db.query(ShiftORM).filter(
+        ShiftORM.gate_id == gate_id,
+        ShiftORM.shift_type == parsed_type,
+        ShiftORM.date == shift_date,
+    ).first()
+    if not shift:
+        raise HTTPException(status_code=404, detail="Shift not found")
+
+    new_op = body.operator_num_worker if body.operator_num_worker is not None else shift.operator_num_worker
+    if new_op and new_op != shift.operator_num_worker:
+        conflict = db.query(ShiftORM).filter(
+            ShiftORM.date == shift_date,
+            ShiftORM.operator_num_worker == new_op,
+            ~((ShiftORM.gate_id == gate_id) & (ShiftORM.shift_type == parsed_type)),
+        ).first()
+        if conflict:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Operator {new_op} already assigned to a shift on {shift_date}",
+            )
+
+    if body.operator_num_worker is not None:
+        shift.operator_num_worker = body.operator_num_worker or None
+    if body.manager_num_worker is not None:
+        shift.manager_num_worker = body.manager_num_worker or None
+
+    db.commit()
+    db.refresh(shift)
+
+    db.expire_all()
+    shift = db.query(ShiftORM).options(
+        joinedload(ShiftORM.gate),
+        joinedload(ShiftORM.operator).joinedload(Operator.worker),
+    ).filter(
+        ShiftORM.gate_id == gate_id,
+        ShiftORM.shift_type == parsed_type,
+        ShiftORM.date == shift_date,
+    ).first()
+
+    return {
+        "id": f"{shift.gate_id}-{shift.shift_type.name}-{shift.date.isoformat()}",
+        "gateId": shift.gate_id,
+        "gateName": shift.gate.label if shift.gate else f"Gate {shift.gate_id}",
+        "shiftType": shift.shift_type.name,
+        "date": shift.date.isoformat(),
+        "operatorId": shift.operator_num_worker or "",
+        "operatorName": shift.operator.worker.name if shift.operator and shift.operator.worker else "",
+        "managerId": shift.manager_num_worker or "",
+    }
+
+
+@router.delete("/shifts/{gate_id}/{shift_type}/{shift_date}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_shift(
+    gate_id: Annotated[int, Path()],
+    shift_type: Annotated[str, Path()],
+    shift_date: Annotated[date, Path()],
+    db: Annotated[Session, Depends(get_db)],
+):
+    """
+    Deletes a shift. Refuses if shift is currently active (today + current shift type).
+    """
+    try:
+        parsed_type = parse_shift_type(shift_type)
+    except ValueError:
+        raise HTTPException(status_code=400, detail=f"Invalid shift_type: {shift_type}")
+
+    shift = db.query(ShiftORM).filter(
+        ShiftORM.gate_id == gate_id,
+        ShiftORM.shift_type == parsed_type,
+        ShiftORM.date == shift_date,
+    ).first()
+    if not shift:
+        raise HTTPException(status_code=404, detail="Shift not found")
+
+    if shift.date == date.today() and shift.shift_type == current_shift_type():
+        raise HTTPException(status_code=409, detail="Cannot delete an active shift")
+
+    db.delete(shift)
+    db.commit()
 
 
 # ==================== OPERATOR ENDPOINTS ====================

--- a/src/V_APP/Data_Module/routes/worker.py
+++ b/src/V_APP/Data_Module/routes/worker.py
@@ -8,7 +8,8 @@ Shift queries use PostgreSQL (shift data not yet projected to MongoDB).
 
 from typing import Annotated, List, Optional, Dict, Any
 from datetime import date, datetime
-from fastapi import APIRouter, Depends, HTTPException, status, Query, Path
+import csv, io
+from fastapi import APIRouter, Depends, HTTPException, status, Query, Path, UploadFile, File
 from sqlalchemy.orm import Session, joinedload
 from pydantic import BaseModel
 from loguru import logger
@@ -447,6 +448,109 @@ def delete_shift(
 
     db.delete(shift)
     db.commit()
+
+
+@router.post("/shifts/bulk", status_code=status.HTTP_200_OK)
+def bulk_create_shifts(
+    file: Annotated[UploadFile, File(description="CSV: gate_id,shift_type,date,operator_num_worker,manager_num_worker")],
+    db: Annotated[Session, Depends(get_db)],
+):
+    """
+    Bulk-create shifts from a CSV file.
+    Required columns: gate_id, shift_type, date
+    Optional columns: operator_num_worker, manager_num_worker
+
+    Returns { created, skipped, errors } — never aborts the whole batch on a single bad row.
+    """
+    content = file.file.read()
+    try:
+        text = content.decode("utf-8-sig")  # handle BOM from Excel exports
+    except UnicodeDecodeError:
+        raise HTTPException(status_code=400, detail="File must be UTF-8 encoded")
+
+    reader = csv.DictReader(io.StringIO(text))
+    required = {"gate_id", "shift_type", "date"}
+    if not required.issubset(set(reader.fieldnames or [])):
+        raise HTTPException(
+            status_code=400,
+            detail=f"CSV must contain columns: {', '.join(sorted(required))}",
+        )
+
+    created, skipped = 0, 0
+    errors: list[dict] = []
+
+    for row_num, row in enumerate(reader, start=2):  # start=2: row 1 is header
+        gate_id_raw    = row.get("gate_id", "").strip()
+        shift_type_raw = row.get("shift_type", "").strip().upper()
+        date_raw       = row.get("date", "").strip()
+        operator_raw   = row.get("operator_num_worker", "").strip() or None
+        manager_raw    = row.get("manager_num_worker", "").strip() or None
+
+        # Basic validation
+        if not gate_id_raw or not shift_type_raw or not date_raw:
+            errors.append({"row": row_num, "reason": "Missing required field (gate_id, shift_type, or date)"})
+            continue
+
+        try:
+            gate_id = int(gate_id_raw)
+        except ValueError:
+            errors.append({"row": row_num, "reason": f"gate_id must be an integer, got '{gate_id_raw}'"})
+            continue
+
+        try:
+            parsed_type = parse_shift_type(shift_type_raw)
+        except ValueError:
+            errors.append({"row": row_num, "reason": f"Invalid shift_type '{shift_type_raw}' — use MORNING, AFTERNOON, or NIGHT"})
+            continue
+
+        try:
+            parsed_date = date.fromisoformat(date_raw)
+        except ValueError:
+            errors.append({"row": row_num, "reason": f"Invalid date '{date_raw}' — use YYYY-MM-DD"})
+            continue
+
+        # Gate must exist and be active
+        gate = db.query(GateORM).filter(GateORM.id == gate_id, GateORM.estado == "Ativo").first()
+        if not gate:
+            errors.append({"row": row_num, "reason": f"Gate {gate_id} not found or inactive"})
+            continue
+
+        # Skip duplicate (gate, type, date)
+        existing = db.query(ShiftORM).filter(
+            ShiftORM.gate_id == gate_id,
+            ShiftORM.shift_type == parsed_type,
+            ShiftORM.date == parsed_date,
+        ).first()
+        if existing:
+            skipped += 1
+            continue
+
+        # Operator conflict (same operator, same date)
+        if operator_raw:
+            conflict = db.query(ShiftORM).filter(
+                ShiftORM.date == parsed_date,
+                ShiftORM.operator_num_worker == operator_raw,
+            ).first()
+            if conflict:
+                errors.append({
+                    "row": row_num,
+                    "reason": f"Operator {operator_raw} already assigned to a shift on {date_raw}",
+                })
+                continue
+
+        db.add(ShiftORM(
+            gate_id=gate_id,
+            shift_type=parsed_type,
+            date=parsed_date,
+            operator_num_worker=operator_raw,
+            manager_num_worker=manager_raw,
+        ))
+        created += 1
+
+    if created > 0:
+        db.commit()
+
+    return {"created": created, "skipped": skipped, "errors": errors}
 
 
 # ==================== OPERATOR ENDPOINTS ====================

--- a/src/V_APP/Data_Module/scripts/data_init_demo.py
+++ b/src/V_APP/Data_Module/scripts/data_init_demo.py
@@ -203,7 +203,7 @@ def _make_visit(db: Session, appt, shift, entry_time, duration_min=None) -> Visi
         shift_date=shift.date,
         entry_time=entry_time,
         out_time=entry_time + timedelta(minutes=duration_min) if duration_min else None,
-        state="completed" if duration_min else "unloading",
+        state="done" if duration_min else "unloading",
     )
     db.add(v)
     db.flush()

--- a/src/V_APP/Data_Module/scripts/data_init_demo.py
+++ b/src/V_APP/Data_Module/scripts/data_init_demo.py
@@ -2,18 +2,14 @@
 """
 PEI 2025 Demo data initializer — Porto de Aveiro.
 
-Populates a rich dataset so the logistics manager dashboard has data on
-first load: completed appointments with visits, historical days, alerts,
-and multiple companies for per-company statistics.
+Populates a rich dataset:
+  - 12 months of completed historical appointments (sustainability CO₂ trend)
+  - Today: 87AX60 in_transit (only), mix of scheduled/in_process/completed/canceled
+  - Multiple companies, terminals, and drivers for per-company statistics
 
 Gate / camera assignment:
   Video1 plates → Gate 1 (Decision Engine / port entry)
   Video2 plates → Gate 2 (Infraction Engine / highway approach)
-
-Plate lists are overridable via env vars:
-  DEMO_VIDEO1_PLATES — JSON array of plate strings
-  DEMO_VIDEO2_PLATES — JSON array of plate strings
-  MAX_ARRIVALS       — cap on appointments per gate (default: all)
 
 Run with:
     DATABASE_URL=postgresql://... python scripts/data_init_demo.py
@@ -52,7 +48,7 @@ except Exception:
 from data_init_base import _hash  # noqa: E402
 
 
-# ── Demo plate configuration (overridable via env vars) ──────────────────────
+# ── Plate configuration ──────────────────────────────────────────────────────
 _DEFAULT_VIDEO1 = ["87AX60", "68BSH8", "PEI2025", "LN67OIZGB", "92BLN3", "82BTN5"]
 _DEFAULT_VIDEO2 = ["321BI13", "GGAB425", "SLJP1523", "CA93896"]
 
@@ -63,97 +59,109 @@ VIDEO2_PLATES: list = _json.loads(
     os.environ.get("DEMO_VIDEO2_PLATES", _json.dumps(_DEFAULT_VIDEO2))
 )
 
-_raw_max = os.environ.get("MAX_ARRIVALS", "")
-MAX_ARRIVALS: int = (
-    int(_raw_max) if _raw_max.isdigit() else max(len(VIDEO1_PLATES), len(VIDEO2_PLATES))
-)
-
-VIDEO1_PLATES = VIDEO1_PLATES[:MAX_ARRIVALS]
-VIDEO2_PLATES = VIDEO2_PLATES[:MAX_ARRIVALS]
-
 # ── Reference data ────────────────────────────────────────────────────────────
 
 COMPANIES = [
-    ("PT509123456", "Transportes Aveiro Lda", "+351 234 567 890"),
-    ("PT509234567", "Iberian Logistics SA", "+351 234 678 901"),
-    ("PT509345678", "EuroTrans Portugal", "+351 234 789 012"),
-    ("ES-B12345678", "Transportes Garcia SL", "+34 91 234 5678"),
-    ("DE123456789", "Schmidt Spedition GmbH", "+49 30 1234567"),
-    ("FR12345678901", "Transports Dupont SARL", "+33 1 23 45 67 89"),
+    ("PT509123456", "Transportes Aveiro Lda",    "+351 234 567 890"),
+    ("PT509234567", "Iberian Logistics SA",       "+351 234 678 901"),
+    ("PT509345678", "EuroTrans Portugal",         "+351 234 789 012"),
+    ("ES-B12345678", "Transportes Garcia SL",     "+34 91 234 5678"),
+    ("DE123456789",  "Schmidt Spedition GmbH",    "+49 30 1234567"),
+    ("FR12345678901","Transports Dupont SARL",    "+33 1 23 45 67 89"),
 ]
 
-# (license, name, company_idx)
 DRIVERS = [
-    ("PT12345678", "Oscar Almeida", 0),
-    ("PT23456789", "Sofia Rodrigues", 0),
-    ("PT34567890", "Miguel Santos", 1),
-    ("PT45678901", "Ana Ferreira", 1),
-    ("PT56789012", "Bruno Costa", 2),
+    ("PT12345678", "Oscar Almeida",       0),
+    ("PT23456789", "Sofia Rodrigues",     0),
+    ("PT34567890", "Miguel Santos",       1),
+    ("PT45678901", "Ana Ferreira",        1),
+    ("PT56789012", "Bruno Costa",         2),
     ("ES87654321", "Carlos Garcia Lopez", 3),
-    ("ES76543210", "Maria Fernandez", 3),
-    ("DE11223344", "Hans Mueller", 4),
-    ("FR99887766", "Pierre Dubois", 5),
-    ("FR88776655", "Jean-Luc Martin", 5),
+    ("ES76543210", "Maria Fernandez",     3),
+    ("DE11223344", "Hans Mueller",        4),
+    ("FR99887766", "Pierre Dubois",       5),
+    ("FR88776655", "Jean-Luc Martin",     5),
 ]
 
-# Extra historical trucks (supplement the demo plates)
-# (plate, brand, company_idx)
-_BRAND_SCANIA = "Scania R500"
-_BRAND_MAN = "MAN TGX"
+_BRAND_SCANIA   = "Scania R500"
+_BRAND_MAN      = "MAN TGX"
 _BRAND_MERCEDES = "Mercedes Actros"
-_BRAND_DAF = "DAF XF"
-_BRAND_VOLVO = "Volvo FH16"
+_BRAND_DAF      = "DAF XF"
+_BRAND_VOLVO    = "Volvo FH16"
+_BRAND_IVECO    = "Iveco S-Way"
 
 EXTRA_TRUCKS = [
-    ("AA00AA", _BRAND_SCANIA, 0),
-    ("BB11BB", _BRAND_MAN, 1),
-    ("CC22CC", _BRAND_MERCEDES, 2),
-    ("DD33DD", _BRAND_DAF, 3),
-    ("12AB34", _BRAND_VOLVO, 0),
-    ("56CD78", _BRAND_SCANIA, 1),
-    ("90EF12", _BRAND_MAN, 2),
-    ("34GH56", _BRAND_MERCEDES, 0),
-    ("78IJ90", _BRAND_DAF, 1),
-    ("23LM45", _BRAND_VOLVO, 0),
-    ("67NP89", _BRAND_SCANIA, 1),
-    ("45ST67", _BRAND_VOLVO, 0),
-    ("89UV01", _BRAND_SCANIA, 1),
-    ("23WX45", _BRAND_MAN, 2),
+    ("AA00AA", _BRAND_SCANIA,   0), ("BB11BB", _BRAND_MAN,      1),
+    ("CC22CC", _BRAND_MERCEDES, 2), ("DD33DD", _BRAND_DAF,      3),
+    ("12AB34", _BRAND_VOLVO,    0), ("56CD78", _BRAND_SCANIA,   1),
+    ("90EF12", _BRAND_MAN,      2), ("34GH56", _BRAND_MERCEDES, 0),
+    ("78IJ90", _BRAND_DAF,      1), ("23LM45", _BRAND_VOLVO,    0),
+    ("67NP89", _BRAND_SCANIA,   1), ("45ST67", _BRAND_VOLVO,    0),
+    ("89UV01", _BRAND_SCANIA,   1), ("23WX45", _BRAND_MAN,      2),
+    ("11YZ22", _BRAND_IVECO,    3), ("33AB44", _BRAND_DAF,      4),
+    ("55CD66", _BRAND_SCANIA,   5), ("77EF88", _BRAND_VOLVO,    0),
+    ("99GH00", _BRAND_MAN,      1), ("11IJ22", _BRAND_MERCEDES, 2),
 ]
 
-# (desc, state, weight_kg, is_hazmat, un_code, kemler)
 CARGO_TYPES = [
-    ("Sulfuric acid (fuming)", "liquid", 22000, True, "1831", "X886"),
-    ("Gasoline ADR", "liquid", 24000, True, "1203", "33"),
-    ("Propane cylinders", "gaseous", 8000, True, "1978", "23"),
-    ("Industrial chemicals", "liquid", 15000, True, "1830", "80"),
-    ("Ammonium nitrate fert.", "solid", 22000, True, "1942", "50"),
-    ("Ceramic tiles", "solid", 24000, False, None, None),
-    ("Cork products", "solid", 8000, False, None, None),
-    ("Paper pulp", "solid", 28000, False, None, None),
-    ("Salt (Salinas Aveiro)", "solid", 26000, False, None, None),
-    ("Fish (fresh catch)", "solid", 12000, False, None, None),
-    ("Wine (Bairrada DOC)", "liquid", 18000, False, None, None),
-    ("Timber (eucalyptus)", "solid", 30000, False, None, None),
-    ("Auto parts", "solid", 16000, False, None, None),
-    ("Construction steel", "solid", 28000, False, None, None),
-    ("Olive oil (bulk)", "liquid", 20000, False, None, None),
-    ("Cement bags", "solid", 25000, False, None, None),
-    ("Plastic granules", "solid", 15000, False, None, None),
-    ("Machinery parts", "solid", 12000, False, None, None),
-    ("Canned fish", "solid", 8000, False, None, None),
-    ("General cargo", "solid", 10000, False, None, None),
+    ("Sulfuric acid (fuming)",   "liquid", 22000, True,  "1831", "X886"),
+    ("Gasoline ADR",             "liquid", 24000, True,  "1203", "33"),
+    ("Propane cylinders",        "gaseous", 8000, True,  "1978", "23"),
+    ("Industrial chemicals",     "liquid", 15000, True,  "1830", "80"),
+    ("Ammonium nitrate fert.",   "solid",  22000, True,  "1942", "50"),
+    ("Ceramic tiles",            "solid",  24000, False, None,   None),
+    ("Cork products",            "solid",   8000, False, None,   None),
+    ("Paper pulp",               "solid",  28000, False, None,   None),
+    ("Salt (Salinas Aveiro)",    "solid",  26000, False, None,   None),
+    ("Fish (fresh catch)",       "solid",  12000, False, None,   None),
+    ("Wine (Bairrada DOC)",      "liquid", 18000, False, None,   None),
+    ("Timber (eucalyptus)",      "solid",  30000, False, None,   None),
+    ("Auto parts",               "solid",  16000, False, None,   None),
+    ("Construction steel",       "solid",  28000, False, None,   None),
+    ("Olive oil (bulk)",         "liquid", 20000, False, None,   None),
+    ("Cement bags",              "solid",  25000, False, None,   None),
+    ("Plastic granules",         "solid",  15000, False, None,   None),
+    ("Machinery parts",          "solid",  12000, False, None,   None),
+    ("Canned fish",              "solid",   8000, False, None,   None),
+    ("General cargo",            "solid",  10000, False, None,   None),
 ]
 
 _ALERT_DESCS = {
-    "safety": "Hazardous cargo safety check triggered",
+    "safety":      "Hazardous cargo safety check triggered",
     "operational": "Dock assignment delay — manual reassignment needed",
-    "problem": "Weight discrepancy detected — cargo exceeds declared weight",
-    "generic": "Documentation check — CMR waybill verified",
+    "problem":     "Weight discrepancy detected — cargo exceeds declared weight",
+    "generic":     "Documentation check — CMR waybill verified",
 }
 
+# ── Per-company delay profiles (lo_min, hi_min, weight) ──────────────────────
+# Drives SLA variation in per-company analytics (Port Performance page).
+# Each tuple is (min_delay_minutes, max_delay_minutes, relative_weight).
+_COMPANY_DELAY_PROFILES: dict = {
+    "PT509123456":  [(0, 4, 52), (5, 14, 32), (15, 29, 12), (30, 70,  4)],  # Transportes Aveiro — excellent
+    "PT509234567":  [(0, 4, 42), (5, 14, 33), (15, 29, 18), (30, 80,  7)],  # Iberian Logistics — good
+    "PT509345678":  [(0, 4, 22), (5, 14, 33), (15, 29, 30), (30, 90, 15)],  # EuroTrans — mediocre
+    "ES-B12345678": [(0, 4, 12), (5, 14, 23), (15, 29, 38), (30, 90, 27)],  # Garcia SL — consistently late
+    "DE123456789":  [(0, 4, 68), (5, 14, 22), (15, 29,  8), (30, 60,  2)],  # Schmidt — punctual (German ops)
+    "FR12345678901":[(0, 4, 28), (5, 14, 34), (15, 29, 26), (30, 85, 12)],  # Dupont — below average
+}
+# Fallback for unlisted companies
+_DEFAULT_DELAY_BUCKETS = [(0, 5, 40), (5, 15, 30), (15, 30, 20), (30, 90, 10)]
 
-# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _random_delay_for_company(company_nif: str) -> int:
+    """Return a realistic delay in minutes for the given company."""
+    profile = _COMPANY_DELAY_PROFILES.get(company_nif, _DEFAULT_DELAY_BUCKETS)
+    buckets, weights = zip(*[((lo, hi), w) for lo, hi, w in profile])
+    lo, hi = random.choices(buckets, weights=weights, k=1)[0]
+    return random.randint(lo, hi)
+
+
+def _random_delay_minutes() -> int:
+    """Pick a delay in minutes using the default weighted buckets (legacy helper)."""
+    return _random_delay_for_company("")
+
+
+# ── Low-level helpers ─────────────────────────────────────────────────────────
 
 def _make_booking(db: Session, ref: str, direction: str = "inbound") -> Booking:
     bk = Booking(reference=ref, direction=direction)
@@ -164,50 +172,12 @@ def _make_booking(db: Session, ref: str, direction: str = "inbound") -> Booking:
 
 def _make_cargo(db: Session, bk_ref: str, cargo_def: tuple) -> Cargo:
     desc, st, weight, is_hazmat, un, kemler = cargo_def
-    label = (
-        f"{desc} [UN:{un}, Kemler:{kemler}]" if is_hazmat else desc
-    )
-    c = Cargo(booking_reference=bk_ref, quantity=Decimal(str(weight)), state=st, description=label)
+    label = f"{desc} [UN:{un}, Kemler:{kemler}]" if is_hazmat else desc
+    c = Cargo(booking_reference=bk_ref, quantity=Decimal(str(weight)),
+              state=st, description=label)
     db.add(c)
     db.flush()
     return c
-
-
-def _make_appointment(
-    db: Session, bk_ref, driver, truck, terminal, gate_in, gate_out,
-    sched_time, status, notes, expected_duration=45, highway_infraction=False,
-) -> Appointment:
-    appt = Appointment(
-        booking_reference=bk_ref,
-        driver_license=driver.drivers_license,
-        truck_license_plate=truck.license_plate,
-        terminal_id=terminal.id,
-        gate_in_id=gate_in.id,
-        gate_out_id=gate_out.id if status == "completed" else None,
-        scheduled_start_time=sched_time,
-        expected_duration=expected_duration,
-        status=status,
-        notes=notes,
-        highway_infraction=highway_infraction,
-    )
-    db.add(appt)
-    db.flush()
-    return appt
-
-
-def _make_visit(db: Session, appt, shift, entry_time, duration_min=None) -> Visit:
-    v = Visit(
-        appointment_id=appt.id,
-        shift_gate_id=shift.gate_id,
-        shift_type=shift.shift_type,
-        shift_date=shift.date,
-        entry_time=entry_time,
-        out_time=entry_time + timedelta(minutes=duration_min) if duration_min else None,
-        state="done" if duration_min else "unloading",
-    )
-    db.add(v)
-    db.flush()
-    return v
 
 
 def _make_alert(db: Session, visit, appt, shift, timestamp, alert_type) -> Alert:
@@ -230,30 +200,73 @@ def _make_alert(db: Session, visit, appt, shift, timestamp, alert_type) -> Alert
     return a
 
 
-def _generate_historical_day(
-    db, day_date, trucks, drivers, terminal, gate_in, gate_out,
-    shifts_morning, shifts_afternoon, num_appts, ref_prefix
-):
-    """Generate a full completed day for volume / statistics data."""
-    for h in range(num_appts):
-        ref = f"{ref_prefix}-{day_date.strftime('%Y%m%d')}-{h+1:04d}"
-        bk = _make_booking(db, ref, "inbound" if h % 4 != 0 else "outbound")
+def _shift_for_time(dt: datetime, shift_m, shift_a, shift_n):
+    """Pick morning/afternoon/night shift based on hour."""
+    h = dt.hour
+    if 6 <= h < 14:
+        return shift_m
+    if 14 <= h < 22:
+        return shift_a
+    return shift_n
 
-        cidx = (h + 5) % len(CARGO_TYPES)
+
+def _get_or_create_day_shifts(
+    db: Session, d: date, gate_entry_id: int,
+    operator_num: str, manager_num: str
+) -> tuple:
+    """Return (morning_shift, afternoon_shift, night_shift) for a given date,
+    creating them if they don't already exist."""
+    result = {}
+    for stype in [ShiftType.MORNING, ShiftType.AFTERNOON, ShiftType.NIGHT]:
+        existing = db.query(Shift).filter(
+            Shift.gate_id == gate_entry_id,
+            Shift.shift_type == stype,
+            Shift.date == d,
+        ).first()
+        if not existing:
+            existing = Shift(
+                gate_id=gate_entry_id, shift_type=stype, date=d,
+                operator_num_worker=operator_num,
+                manager_num_worker=manager_num,
+            )
+            db.add(existing)
+            db.flush()
+        result[stype] = existing
+    return result[ShiftType.MORNING], result[ShiftType.AFTERNOON], result[ShiftType.NIGHT]
+
+
+# ── Historical day generator ──────────────────────────────────────────────────
+
+def _generate_historical_day(
+    db: Session, day_date: date, trucks, drivers,
+    terminal, gate_in, gate_out,
+    shift_m, shift_a, shift_n,
+    num_appts: int, ref_prefix: str, counter: list,
+):
+    """Generate a full completed day of appointments with realistic delays."""
+    for h in range(num_appts):
+        counter[0] += 1
+        ref = f"{ref_prefix}-{day_date.strftime('%Y%m%d')}-{counter[0]:05d}"
+        bk = _make_booking(db, ref, "inbound" if h % 5 != 0 else "outbound")
+        cidx = (h + counter[0]) % len(CARGO_TYPES)
         _make_cargo(db, bk.reference, CARGO_TYPES[cidx])
 
-        hour_offset = random.choice([7, 8, 8, 9, 9, 10, 10, 11, 12, 13, 14, 14, 15, 16, 17])
+        hour_offset = random.choice([7, 7, 8, 8, 9, 9, 10, 10, 11, 12, 13, 14, 15, 15, 16, 17, 17])
         sched = datetime.combine(day_date, time(hour_offset, random.randint(0, 55)))
 
-        tidx = h % len(trucks)
-        didx = h % len(drivers)
-        dur = random.choice([20, 25, 30, 35, 38, 42, 45, 50, 55, 60, 70, 80])
-        delay = random.choice([0, 0, 0, 5, 10, 15, 20, 30])
+        truck = trucks[h % len(trucks)]
+        driver = drivers[h % len(drivers)]
+        dur = random.choice([20, 25, 30, 35, 38, 40, 42, 45, 50, 55, 60, 70, 80])
+        # Use company-specific delay profile so per-company SLA varies realistically
+        delay = _random_delay_for_company(truck.company_nif)
+
+        # ~8% of appointments have a highway infraction (hazmat/speed/docs)
+        is_infraction = random.random() < 0.08
 
         appt = Appointment(
             booking_reference=bk.reference,
-            driver_license=drivers[didx].drivers_license,
-            truck_license_plate=trucks[tidx].license_plate,
+            driver_license=driver.drivers_license,
+            truck_license_plate=truck.license_plate,
             terminal_id=terminal.id,
             gate_in_id=gate_in.id,
             gate_out_id=gate_out.id,
@@ -261,25 +274,40 @@ def _generate_historical_day(
             expected_duration=45,
             status="completed",
             notes=f"Historical — {CARGO_TYPES[cidx][0]}",
+            highway_infraction=is_infraction,
         )
         db.add(appt)
         db.flush()
 
-        entry = sched + timedelta(minutes=delay + random.randint(1, 5))
-        shift = shifts_morning if entry.hour < 14 else shifts_afternoon
-        v = _make_visit(db, appt, shift, entry, dur)
+        entry = sched + timedelta(minutes=delay + random.randint(1, 3))
+        shift = _shift_for_time(entry, shift_m, shift_a, shift_n)
+        v = Visit(
+            appointment_id=appt.id,
+            shift_gate_id=shift.gate_id,
+            shift_type=shift.shift_type,
+            shift_date=shift.date,
+            entry_time=entry,
+            out_time=entry + timedelta(minutes=dur),
+            state="done",
+        )
+        db.add(v)
+        db.flush()
 
-        if random.random() < 0.25:
-            at = random.choice(["safety", "operational", "problem", "generic"])
+        # Operational alert rate: 18% generic, plus mandatory alert for infractions
+        if is_infraction:
+            at = random.choice(["safety", "safety", "problem"])
+            _make_alert(db, v, appt, shift, entry + timedelta(minutes=random.randint(2, 8)), at)
+        elif random.random() < 0.12:
+            at = random.choice(["operational", "problem", "generic"])
             _make_alert(db, v, appt, shift, entry + timedelta(minutes=random.randint(2, 15)), at)
 
 
 # ── Main seeder ───────────────────────────────────────────────────────────────
 
 def init_demo_data(db: Session):
-    print("=" * 60)
+    print("=" * 65)
     print("  PEI 2025 — PORTO DE AVEIRO DEMO DATA INITIALIZER")
-    print("=" * 60)
+    print("=" * 65)
 
     if db.query(Worker).first():
         print("\n  Data already exists — skipping initialization.")
@@ -288,7 +316,7 @@ def init_demo_data(db: Session):
 
     try:
         today = date.today()
-        now = datetime.now()
+        now   = datetime.now()
 
         # ── Workers ──────────────────────────────────────────────────────────
         print("\n  Creating workers...")
@@ -343,7 +371,7 @@ def init_demo_data(db: Session):
             drivers.append(d)
         db.add_all(drivers)
         db.flush()
-        main_driver = drivers[0]  # Oscar Almeida — demo star
+        main_driver = drivers[0]  # Oscar Almeida
 
         # ── Trucks ────────────────────────────────────────────────────────────
         all_demo_plates = VIDEO1_PLATES + VIDEO2_PLATES
@@ -354,7 +382,7 @@ def init_demo_data(db: Session):
         for i, plate in enumerate(all_demo_plates):
             t = Truck(
                 license_plate=plate,
-                brand=["Volvo", "Scania", "MAN", "Mercedes", "DAF"][i % 5],
+                brand=[_BRAND_VOLVO, _BRAND_SCANIA, _BRAND_MAN, _BRAND_MERCEDES, _BRAND_DAF][i % 5],
                 company_nif=companies[i % len(companies)].nif,
             )
             db.add(t)
@@ -370,11 +398,10 @@ def init_demo_data(db: Session):
                 all_trucks_list.append(t)
         db.flush()
 
-        # Extra trucks (not in demo plate lists) for historical variety
         hist_trucks = [t for t in all_trucks_list if t.license_plate not in set(all_demo_plates)]
 
-        # ── Terminals (real Porto de Aveiro) ──────────────────────────────────
-        print("  Creating terminals (Terminal Norte, Granéis Sólidos, Granéis Líquidos)...")
+        # ── Terminals ────────────────────────────────────────────────────────
+        print("  Creating terminals...")
         terminal_norte = Terminal(
             name="Terminal Norte - Porto de Aveiro",
             latitude=Decimal("40.6520"), longitude=Decimal("-8.7430"),
@@ -396,17 +423,17 @@ def init_demo_data(db: Session):
         # ── Docks ─────────────────────────────────────────────────────────────
         print("  Creating docks...")
         docks = [
-            Dock(terminal_id=terminal_norte.id, bay_number="TN-CAIS-1",
+            Dock(terminal_id=terminal_norte.id,    bay_number="TN-CAIS-1",
                  latitude=Decimal("40.6522"), longitude=Decimal("-8.7428"), current_usage="operational"),
-            Dock(terminal_id=terminal_norte.id, bay_number="TN-CAIS-2",
+            Dock(terminal_id=terminal_norte.id,    bay_number="TN-CAIS-2",
                  latitude=Decimal("40.6524"), longitude=Decimal("-8.7426"), current_usage="operational"),
-            Dock(terminal_id=terminal_norte.id, bay_number="TN-RORO",
+            Dock(terminal_id=terminal_norte.id,    bay_number="TN-RORO",
                  latitude=Decimal("40.6518"), longitude=Decimal("-8.7432"), current_usage="operational"),
-            Dock(terminal_id=terminal_solidos.id, bay_number="TGS-CAIS-A",
+            Dock(terminal_id=terminal_solidos.id,  bay_number="TGS-CAIS-A",
                  latitude=Decimal("40.6448"), longitude=Decimal("-8.7492"), current_usage="operational"),
-            Dock(terminal_id=terminal_solidos.id, bay_number="TGS-CAIS-B",
+            Dock(terminal_id=terminal_solidos.id,  bay_number="TGS-CAIS-B",
                  latitude=Decimal("40.6450"), longitude=Decimal("-8.7494"), current_usage="operational"),
-            Dock(terminal_id=terminal_solidos.id, bay_number="TGS-SILO",
+            Dock(terminal_id=terminal_solidos.id,  bay_number="TGS-SILO",
                  latitude=Decimal("40.6444"), longitude=Decimal("-8.7488"), current_usage="operational"),
             Dock(terminal_id=terminal_liquidos.id, bay_number="TGL-CAIS-1",
                  latitude=Decimal("40.6362"), longitude=Decimal("-8.7522"), current_usage="operational"),
@@ -435,232 +462,381 @@ def init_demo_data(db: Session):
         db.add_all([gate_entry, gate_out, gate_highway])
         db.flush()
 
-        # ── Shifts (today + 5 historical days) ───────────────────────────────
-        print("  Creating shifts (today + 5 historical days)...")
-        shift_map: dict = {}
-        operators_cycle = ["OPR001", "OPR002", "OPR001", "OPR002"]
-        for day_offset in range(6):
-            d = today - timedelta(days=day_offset)
-            configs = [
-                (gate_entry.id,  ShiftType.MORNING,   d, operators_cycle[0], "MGR001"),
-                (gate_entry.id,  ShiftType.AFTERNOON, d, operators_cycle[1], "MGR001"),
-                (gate_entry.id,  ShiftType.NIGHT,     d, operators_cycle[2], "MGR002"),
-                (gate_highway.id, ShiftType.MORNING,  d, operators_cycle[3], "MGR002"),
-                (gate_highway.id, ShiftType.AFTERNOON, d, operators_cycle[0], "MGR002"),
-            ]
-            for gid, stype, sdate, opr, mgr in configs:
-                s = Shift(gate_id=gid, shift_type=stype, date=sdate,
-                          operator_num_worker=opr, manager_num_worker=mgr)
-                db.add(s)
-                shift_map[(gid, stype, sdate)] = s
+        # ── Today's shifts (full, with operators) ─────────────────────────────
+        print("  Creating today's shifts...")
+        ops = ["OPR001", "OPR002"]
+        today_shifts = {}
+        for gid, stype, opr, mgr in [
+            (gate_entry.id,   ShiftType.MORNING,   ops[0], "MGR001"),
+            (gate_entry.id,   ShiftType.AFTERNOON, ops[1], "MGR001"),
+            (gate_entry.id,   ShiftType.NIGHT,     ops[0], "MGR002"),
+            (gate_highway.id, ShiftType.MORNING,   ops[1], "MGR002"),
+            (gate_highway.id, ShiftType.AFTERNOON, ops[0], "MGR002"),
+        ]:
+            s = Shift(gate_id=gid, shift_type=stype, date=today,
+                      operator_num_worker=opr, manager_num_worker=mgr)
+            db.add(s)
+            today_shifts[(gid, stype)] = s
         db.flush()
 
-        morning_shift   = shift_map[(gate_entry.id, ShiftType.MORNING,   today)]
-        afternoon_shift = shift_map[(gate_entry.id, ShiftType.AFTERNOON, today)]
-        night_shift     = shift_map[(gate_entry.id, ShiftType.NIGHT,     today)]
+        morning_today   = today_shifts[(gate_entry.id, ShiftType.MORNING)]
+        afternoon_today = today_shifts[(gate_entry.id, ShiftType.AFTERNOON)]
+        night_today     = today_shifts[(gate_entry.id, ShiftType.NIGHT)]
 
-        ref_counter = [0]
+        def _shift_today(dt: datetime):
+            return _shift_for_time(dt, morning_today, afternoon_today, night_today)
 
-        def _next_ref(prefix="AVR"):
-            ref_counter[0] += 1
-            return f"{prefix}-{today.strftime('%Y%m%d')}-{ref_counter[0]:04d}"
-
-        def _shift_for(dt: datetime):
-            h = dt.hour
-            if 6 <= h < 14:
-                return morning_shift
-            if 14 <= h < 22:
-                return afternoon_shift
-            return night_shift
-
-        def _auto_status(sched_dt: datetime, dur_min) -> str:
-            """Compute realistic appointment status relative to now."""
-            elapsed = (now - sched_dt).total_seconds() / 60
-            if elapsed < -5:
-                return "scheduled"
-            if dur_min is None or elapsed < dur_min:
-                return "in_process"
-            return "completed"
-
-        def _sched(h: int, m: int = 0) -> datetime:
-            """Absolute time today; if in the future keep as-is (scheduled)."""
-            return datetime.combine(today, time(h, m))
-
-        # ── Video1 appointments — Gate 1, spread across all 3 shifts ─────────
-        # Times chosen so each shift has ≥1 demo plate regardless of script time.
-        print(f"\n  Creating {len(VIDEO1_PLATES)} Video1 appointments (Gate 1)...")
-        _VIDEO1_TIMES = [
-            time(7, 30),   # morning
-            time(9, 0),    # morning
-            time(11, 30),  # morning
-            time(14, 30),  # afternoon
-            time(16, 0),   # afternoon
-            time(22, 15),  # night
-        ]
-        # Plates at index 1 and 4 get highway infraction at Gate 1
-        _VIDEO1_INFRACTION_INDICES = {1, 4}
-        for i, plate in enumerate(VIDEO1_PLATES):
-            cargo_def = CARGO_TYPES[i % len(CARGO_TYPES)]
-            desc, _, _, is_hazmat, un_code, kemler = cargo_def
-            bk = _make_booking(db, _next_ref())
-            _make_cargo(db, bk.reference, cargo_def)
-            slot_time = _VIDEO1_TIMES[i % len(_VIDEO1_TIMES)]
-            sched_time = datetime.combine(today, slot_time)
-            status = _auto_status(sched_time, 45)
-            has_infraction = i in _VIDEO1_INFRACTION_INDICES
-            # Infraction only makes sense once the truck has been detected on the road
-            detected_infraction = has_infraction and status != "scheduled"
-            notes = (
-                f"HAZMAT: {desc} [UN:{un_code}, Kemler:{kemler}]"
-                if is_hazmat else f"Cargo: {desc}"
-            )
-            if detected_infraction:
-                notes += " — INFRAÇÃO DETECTADA A25"
-            appt = _make_appointment(
-                db, bk.reference, main_driver, trucks_by_plate[plate],
-                terminal_liquidos if is_hazmat else terminal_norte,
-                gate_entry, gate_out, sched_time, status, notes,
-                highway_infraction=detected_infraction,
-            )
-            if status in ("completed", "in_process"):
-                entry = sched_time + timedelta(minutes=random.randint(2, 8))
-                dur = 45 if status == "completed" else None
-                v = _make_visit(db, appt, _shift_for(entry), entry, dur)
-
-        # ── Video2 appointments — Gate highway, spread across all 3 shifts ────
-        print(f"  Creating {len(VIDEO2_PLATES)} Video2 appointments (Gate 2 / highway)...")
-        _VIDEO2_TIMES = [
-            time(8, 0),    # morning
-            time(15, 30),  # afternoon
-            time(18, 0),   # afternoon
-            time(22, 45),  # night
-        ]
-        for i, plate in enumerate(VIDEO2_PLATES):
-            cargo_def = CARGO_TYPES[i % len(CARGO_TYPES)]
-            desc, _, _, is_hazmat, un_code, kemler = cargo_def
-            bk = _make_booking(db, _next_ref("HWY"))
-            _make_cargo(db, bk.reference, cargo_def)
-            slot_time = _VIDEO2_TIMES[i % len(_VIDEO2_TIMES)]
-            sched_time = datetime.combine(today, slot_time)
-            status = _auto_status(sched_time, 40)
-            # Hazmat trucks on the highway gate are an infraction only once detected
-            highway_infraction = is_hazmat and status != "scheduled"
-            notes = f"Highway — {'HAZMAT: ' + desc if is_hazmat else 'Cargo: ' + desc}"
-            if highway_infraction:
-                notes += " — INFRAÇÃO DETECTADA A25"
-            appt = _make_appointment(
-                db, bk.reference, drivers[i % len(drivers)], trucks_by_plate[plate],
-                terminal_liquidos if is_hazmat else terminal_solidos,
-                gate_highway, gate_out, sched_time, status, notes,
-                highway_infraction=highway_infraction,
-            )
-            if status in ("completed", "in_process"):
-                entry = sched_time + timedelta(minutes=random.randint(2, 8))
-                dur = 40 if status == "completed" else None
-                v = _make_visit(db, appt, _shift_for(entry), entry, dur)
-
-        # ── Bonus appointments distributed across all 3 shifts ────────────────
-        # Each entry: (truck_idx, cargo_idx, hour, min, dur_min|None, alert_type)
-        # Status is computed dynamically so the demo is always realistic.
-        print("  Creating bonus today appointments distributed across shifts...")
-        bonus_configs = [
-            # Morning shift (6–14h)
-            (0,  1,   6, 45,  35,   "operational"),
-            (1,  6,   7, 30,  28,   None),
-            (2,  7,   8, 10,  42,   None),
-            (3,  8,   8, 50,  31,   "safety"),
-            (4,  9,  10, 30,  None, None),        # in_process if still before 12:00
-            (5,  5,  11,  0,  55,   "problem"),
-            (6, 10,  12, 15,  38,   None),
-            (7, 11,  13,  0,  60,   None),
-            # Afternoon shift (14–22h)
-            (8, 12,  14, 30,  70,   None),
-            (9, 13,  15, 45,  45,   "generic"),
-            (10, 14, 16,  0,  30,   None),
-            (11, 15, 17, 30, None,  "operational"),  # in_process if still afternoon
-            (12, 16, 18,  0,  85,   None),
-            (13, 17, 19, 30,  48,   None),
-            # Night shift (22–6h)
-            (0,  18, 22, 30,  40,   None),
-            (1,  19, 23,  0,  35,   None),
-        ]
-
-        for bidx, (tidx, cidx, bh, bm, dur, alert_t) in enumerate(bonus_configs):
-            truck = hist_trucks[tidx % len(hist_trucks)]
-            cargo_def = CARGO_TYPES[cidx % len(CARGO_TYPES)]
-            desc, _, _, is_hazmat, _, _ = cargo_def
-
-            bk = _make_booking(db, _next_ref("BON"), "inbound" if bidx % 3 != 0 else "outbound")
-            _make_cargo(db, bk.reference, cargo_def)
-
-            sched_time = _sched(bh, bm)
-            status = _auto_status(sched_time, dur)
-            appt_terminal = terminal_liquidos if is_hazmat else terminal_norte
-            appt = _make_appointment(
-                db, bk.reference, drivers[bidx % len(drivers)], truck,
-                appt_terminal, gate_entry, gate_out, sched_time, status,
-                f"Cargo: {desc}",
-            )
-            if status in ("completed", "in_process"):
-                entry = sched_time + timedelta(minutes=random.randint(2, 10))
-                visit_dur = dur if status == "completed" else None
-                v = _make_visit(db, appt, _shift_for(entry), entry, visit_dur)
-                if alert_t:
-                    _make_alert(db, v, appt, _shift_for(entry),
-                                entry + timedelta(minutes=random.randint(3, 12)), alert_t)
-
-        # ── Peak hour cluster (9–10 AM) for congestion simulation ─────────────
-        peak_configs = [
-            (9, 10, 50), (9, 25, 42), (9, 40, 38), (9, 55, 55), (10, 5, 35), (10, 20, 45),
-        ]
-        for ph, pm, dur in peak_configs:
-            tidx = ref_counter[0] % len(hist_trucks)
-            truck = hist_trucks[tidx]
-            cargo_def = CARGO_TYPES[ref_counter[0] % len(CARGO_TYPES)]
-            bk = _make_booking(db, _next_ref("PEAK"))
-            _make_cargo(db, bk.reference, cargo_def)
-            sched = _sched(ph, pm)
-            status = _auto_status(sched, dur)
-            appt = _make_appointment(
-                db, bk.reference, drivers[ref_counter[0] % len(drivers)], truck,
-                terminal_norte, gate_entry, gate_out, sched, status,
-                f"Peak-hour — {cargo_def[0]}",
-            )
-            if status in ("completed", "in_process"):
-                entry = sched + timedelta(minutes=random.randint(2, 8))
-                visit_dur = dur if status == "completed" else None
-                v = _make_visit(db, appt, _shift_for(entry), entry, visit_dur)
-                if random.random() < 0.3:
-                    at = random.choice(["operational", "generic"])
-                    _make_alert(db, v, appt, _shift_for(entry), entry + timedelta(minutes=5), at)
-
-        # ── Historical data (5 previous days) ─────────────────────────────────
-        print("  Creating 5 days of historical data...")
-        historical_appts_per_day = [12, 10, 14, 11, 13]
-        hist_terminals_cycle = [
-            terminal_norte, terminal_solidos, terminal_liquidos,
-            terminal_norte, terminal_solidos,
-        ]
-
+        # ── Historical shifts (last 5 days, before the 12-month bulk) ─────────
+        print("  Creating recent historical shifts (5 days)...")
+        recent_shift_map: dict = {}
         for day_offset in range(1, 6):
             d = today - timedelta(days=day_offset)
-            sm = shift_map[(gate_entry.id, ShiftType.MORNING, d)]
-            sa = shift_map[(gate_entry.id, ShiftType.AFTERNOON, d)]
+            sm, sa, sn = _get_or_create_day_shifts(
+                db, d, gate_entry.id, ops[day_offset % 2], "MGR001"
+            )
+            recent_shift_map[d] = (sm, sa, sn)
+
+        # ── 12-month historical shifts (bulk, minimal operator info) ──────────
+        print("  Creating 12-month historical shifts (may take a moment)...")
+        hist_shift_map: dict = {}
+        # We only need gate_entry shifts for historical data
+        start_date = today - timedelta(days=365)
+        d = start_date
+        while d < today - timedelta(days=5):
+            # Skip Sundays (very low activity)
+            if d.weekday() != 6:
+                sm, sa, sn = _get_or_create_day_shifts(
+                    db, d, gate_entry.id, ops[d.toordinal() % 2], "MGR001"
+                )
+                hist_shift_map[d] = (sm, sa, sn)
+            d += timedelta(days=1)
+        print(f"    Created shifts for {len(hist_shift_map)} historical days")
+
+        # ── Ref counter (global, unique across all appointments) ───────────────
+        counter = [0]
+
+        def _next_ref(prefix="AVR"):
+            counter[0] += 1
+            return f"{prefix}-{counter[0]:06d}"
+
+        # ─────────────────────────────────────────────────────────────────────
+        # TODAY'S APPOINTMENTS — explicit statuses, 87AX60 is the only in_transit
+        # ─────────────────────────────────────────────────────────────────────
+        print("\n  Creating today's appointments...")
+
+        # ── 87AX60 — IN TRANSIT (trial truck, HAZMAT, scheduled 30 min ahead) ─
+        sched_87 = now + timedelta(minutes=30)
+        bk_87 = _make_booking(db, _next_ref("DEMO"), "inbound")
+        _make_cargo(db, bk_87.reference, CARGO_TYPES[0])  # Sulfuric acid
+        appt_87 = Appointment(
+            booking_reference=bk_87.reference,
+            driver_license=main_driver.drivers_license,
+            truck_license_plate="87AX60",
+            terminal_id=terminal_liquidos.id,
+            gate_in_id=gate_entry.id, gate_out_id=None,
+            scheduled_start_time=sched_87,
+            expected_duration=45,
+            status="in_transit",
+            notes="HAZMAT: Sulfuric acid [UN:1831, Kemler:X886] — awaiting gate detection",
+            highway_infraction=False,
+        )
+        db.add(appt_87)
+        db.flush()
+        print(f"    [in_transit ] 87AX60  (id={appt_87.id})")
+
+        # ── SCHEDULED (future today) ──────────────────────────────────────────
+        scheduled_specs = [
+            # (plate, driver_idx, cargo_idx, hours_ahead, terminal, infraction)
+            ("68BSH8",   1, 6,  1.5, terminal_norte,    False),  # Cork products
+            ("PEI2025",  2, 8,  2.0, terminal_solidos,  False),  # Salt
+            ("LN67OIZGB",3, 12, 3.0, terminal_norte,    False),  # Auto parts
+            ("SLJP1523", 4, 19, 4.0, terminal_solidos,  False),  # General cargo
+            ("GGAB425",  5, 11, 2.5, terminal_solidos,  False),  # Timber
+        ]
+        for plate, didx, cidx, hrs_ahead, terminal, infrct in scheduled_specs:
+            sched_t = now + timedelta(hours=hrs_ahead)
+            bk = _make_booking(db, _next_ref(), "inbound")
+            _make_cargo(db, bk.reference, CARGO_TYPES[cidx])
+            appt = Appointment(
+                booking_reference=bk.reference,
+                driver_license=drivers[didx % len(drivers)].drivers_license,
+                truck_license_plate=plate,
+                terminal_id=terminal.id,
+                gate_in_id=gate_entry.id, gate_out_id=None,
+                scheduled_start_time=sched_t,
+                expected_duration=45,
+                status="scheduled",
+                notes=f"Cargo: {CARGO_TYPES[cidx][0]}",
+                highway_infraction=infrct,
+            )
+            db.add(appt)
+            db.flush()
+            print(f"    [scheduled  ] {plate:12s} (sched +{hrs_ahead:.1f}h)")
+
+        # ── IN PROCESS (inside the port, unloading) ────────────────────────────
+        in_process_specs = [
+            # (plate, driver_idx, cargo_idx, sched_h, entry_delay_min, dur_so_far)
+            ("92BLN3",  2, 7,  now.hour - 1, 8,  30),   # Paper pulp
+            ("82BTN5",  1, 13, now.hour - 1, 12, 15),   # Construction steel
+        ]
+        for plate, didx, cidx, sched_h, entry_delay, dur_so_far in in_process_specs:
+            sched_t = datetime.combine(today, time(max(6, min(sched_h, 21)), random.randint(0, 30)))
+            entry_t = sched_t + timedelta(minutes=entry_delay)
+            bk = _make_booking(db, _next_ref(), "inbound")
+            _make_cargo(db, bk.reference, CARGO_TYPES[cidx])
+            appt = Appointment(
+                booking_reference=bk.reference,
+                driver_license=drivers[didx % len(drivers)].drivers_license,
+                truck_license_plate=plate,
+                terminal_id=terminal_norte.id,
+                gate_in_id=gate_entry.id, gate_out_id=None,
+                scheduled_start_time=sched_t,
+                expected_duration=45,
+                status="in_process",
+                notes=f"Cargo: {CARGO_TYPES[cidx][0]}",
+            )
+            db.add(appt)
+            db.flush()
+            shift = _shift_today(entry_t)
+            db.add(Visit(
+                appointment_id=appt.id,
+                shift_gate_id=shift.gate_id, shift_type=shift.shift_type, shift_date=shift.date,
+                entry_time=entry_t, out_time=None, state="unloading",
+            ))
+            db.flush()
+            print(f"    [in_process ] {plate:12s} (entered {dur_so_far} min ago)")
+
+        # ── COMPLETED (earlier today) ──────────────────────────────────────────
+        completed_specs = [
+            # (plate, driver_idx, cargo_idx, hours_ago, delay_min, dur_min, terminal, infraction)
+            ("321BI13",  6, 5,  4.0, 25, 38, terminal_norte,    True),   # Ceramic tiles, infraction
+            ("CA93896",  7, 9,  3.0,  5, 42, terminal_solidos,  False),  # Fish
+            ("82BTN5",   3, 16, 6.0,  3, 55, terminal_solidos,  False),  # Plastic granules (second run)
+            (hist_trucks[0].license_plate, 8, 18, 5.5, 18, 40, terminal_norte, False),  # Machinery
+            (hist_trucks[1].license_plate, 9, 14, 7.0, 35, 60, terminal_solidos, False), # Olive oil
+            (hist_trucks[2].license_plate, 4, 11, 8.0,  0, 32, terminal_norte, False),  # Timber
+            (hist_trucks[3].license_plate, 1, 8,  2.5,  8, 45, terminal_solidos, False), # Salt
+        ]
+        for plate, didx, cidx, hrs_ago, delay_min, dur_min, terminal, infrct in completed_specs:
+            sched_t = now - timedelta(hours=hrs_ago)
+            entry_t = sched_t + timedelta(minutes=delay_min)
+            exit_t  = entry_t + timedelta(minutes=dur_min)
+            bk = _make_booking(db, _next_ref(), "inbound")
+            _make_cargo(db, bk.reference, CARGO_TYPES[cidx])
+            appt = Appointment(
+                booking_reference=bk.reference,
+                driver_license=drivers[didx % len(drivers)].drivers_license,
+                truck_license_plate=plate,
+                terminal_id=terminal.id,
+                gate_in_id=gate_entry.id, gate_out_id=gate_out.id,
+                scheduled_start_time=sched_t,
+                expected_duration=45,
+                status="completed",
+                notes=f"Cargo: {CARGO_TYPES[cidx][0]}",
+                highway_infraction=infrct,
+            )
+            db.add(appt)
+            db.flush()
+            shift = _shift_today(entry_t)
+            v = Visit(
+                appointment_id=appt.id,
+                shift_gate_id=shift.gate_id, shift_type=shift.shift_type, shift_date=shift.date,
+                entry_time=entry_t, out_time=exit_t, state="done",
+            )
+            db.add(v)
+            db.flush()
+            if infrct:
+                _make_alert(db, v, appt, shift, entry_t + timedelta(minutes=5), "safety")
+            print(f"    [completed  ] {plate:12s} ({hrs_ago:.1f}h ago, delay={delay_min}min)")
+
+        # ── CANCELED (1-2 today) ───────────────────────────────────────────────
+        canceled_specs = [
+            ("LN67OIZGB", 3, 15, 5.0),  # Canceled cement — same plate also has scheduled, different booking
+        ]
+        for plate, didx, cidx, hrs_ago in canceled_specs:
+            sched_t = now - timedelta(hours=hrs_ago)
+            bk = _make_booking(db, _next_ref(), "inbound")
+            _make_cargo(db, bk.reference, CARGO_TYPES[cidx])
+            appt = Appointment(
+                booking_reference=bk.reference,
+                driver_license=drivers[didx % len(drivers)].drivers_license,
+                truck_license_plate=plate,
+                terminal_id=terminal_solidos.id,
+                gate_in_id=gate_entry.id, gate_out_id=None,
+                scheduled_start_time=sched_t,
+                expected_duration=45,
+                status="canceled",
+                notes=f"Cargo: {CARGO_TYPES[cidx][0]} — cancelado por indisponibilidade de cais",
+            )
+            db.add(appt)
+            db.flush()
+            print(f"    [canceled   ] {plate:12s}")
+
+        # ── Extra completed today (more data for wait histogram + dashboard) ────
+        # Uses hist_trucks to avoid plate conflicts with live demo trucks.
+        # Spans a spread of delays so all 4 histogram buckets have values.
+        extra_completed_today = [
+            # (truck_idx, driver_idx, cargo_idx, hrs_ago, delay_min, dur_min, terminal, infraction)
+            (4,  0, 2,  1.5,  3, 28, terminal_liquidos,  False),  # Propane, on-time
+            (5,  1, 6,  2.0,  7, 40, terminal_norte,     False),  # Cork, minor delay
+            (6,  2, 7,  2.5,  9, 35, terminal_solidos,   False),  # Paper pulp, minor
+            (7,  3, 10, 3.0, 18, 55, terminal_solidos,   False),  # Fish, delayed
+            (8,  4, 11, 3.5, 22, 48, terminal_norte,     True),   # Timber, infraction
+            (9,  5, 13, 4.5,  2, 33, terminal_norte,     False),  # Steel, on-time
+            (10, 6, 16, 5.0, 42, 60, terminal_solidos,   False),  # Plastic, very late
+            (11, 7, 19, 5.5,  0, 25, terminal_norte,     False),  # General, on-time
+            (12, 8, 5,  6.5, 33, 45, terminal_solidos,   True),   # Ceramics, infraction
+            (13, 9, 14, 7.5,  6, 38, terminal_liquidos,  False),  # Olive oil, minor
+        ]
+        for tidx, didx, cidx, hrs_ago, delay_min, dur_min, terminal, infrct in extra_completed_today:
+            truck = hist_trucks[tidx % len(hist_trucks)]
+            sched_t = now - timedelta(hours=hrs_ago)
+            entry_t = sched_t + timedelta(minutes=delay_min)
+            exit_t  = entry_t + timedelta(minutes=dur_min)
+            bk = _make_booking(db, _next_ref("EXT"), "inbound")
+            _make_cargo(db, bk.reference, CARGO_TYPES[cidx])
+            appt = Appointment(
+                booking_reference=bk.reference,
+                driver_license=drivers[didx % len(drivers)].drivers_license,
+                truck_license_plate=truck.license_plate,
+                terminal_id=terminal.id,
+                gate_in_id=gate_entry.id, gate_out_id=gate_out.id,
+                scheduled_start_time=sched_t,
+                expected_duration=45,
+                status="completed",
+                notes=f"Cargo: {CARGO_TYPES[cidx][0]}",
+                highway_infraction=infrct,
+            )
+            db.add(appt)
+            db.flush()
+            shift = _shift_today(entry_t)
+            v = Visit(
+                appointment_id=appt.id,
+                shift_gate_id=shift.gate_id, shift_type=shift.shift_type, shift_date=shift.date,
+                entry_time=entry_t, out_time=exit_t, state="done",
+            )
+            db.add(v)
+            db.flush()
+            if infrct:
+                _make_alert(db, v, appt, shift, entry_t + timedelta(minutes=4), "safety")
+            print(f"    [completed+ ] {truck.license_plate:12s} ({hrs_ago:.1f}h ago, delay={delay_min}min)")
+
+        # ── Highway gate appointments (Video2 plates, today) ──────────────────
+        v2_today_specs = [
+            # (plate, didx, cidx, status, sched_offset_h, delay_min, dur_min, infraction)
+            ("321BI13",  5, 1, "completed", -5.0, 10, 38, True),   # Gasoline ADR, infraction
+            ("GGAB425",  6, 4, "completed", -4.0,  5, 45, False),  # Ammonium nitrate
+            ("CA93896",  7, 3, "scheduled",  2.0,  0,  0, False),  # Industrial chemicals future
+        ]
+        hw_shift_m = today_shifts[(gate_highway.id, ShiftType.MORNING)]
+        hw_shift_a = today_shifts[(gate_highway.id, ShiftType.AFTERNOON)]
+        for plate, didx, cidx, status, sched_off_h, delay_min, dur_min, infrct in v2_today_specs:
+            sched_t = now + timedelta(hours=sched_off_h)
+            bk = _make_booking(db, _next_ref("HWY"), "inbound")
+            _make_cargo(db, bk.reference, CARGO_TYPES[cidx])
+            appt = Appointment(
+                booking_reference=bk.reference,
+                driver_license=drivers[didx % len(drivers)].drivers_license,
+                truck_license_plate=plate,
+                terminal_id=terminal_liquidos.id,
+                gate_in_id=gate_highway.id, gate_out_id=gate_out.id if status == "completed" else None,
+                scheduled_start_time=sched_t,
+                expected_duration=40,
+                status=status,
+                notes=f"Highway — {CARGO_TYPES[cidx][0]}",
+                highway_infraction=infrct,
+            )
+            db.add(appt)
+            db.flush()
+            if status == "completed":
+                entry_t = sched_t + timedelta(minutes=delay_min)
+                exit_t  = entry_t + timedelta(minutes=dur_min)
+                hw_shift = hw_shift_m if entry_t.hour < 14 else hw_shift_a
+                v = Visit(
+                    appointment_id=appt.id,
+                    shift_gate_id=hw_shift.gate_id, shift_type=hw_shift.shift_type, shift_date=hw_shift.date,
+                    entry_time=entry_t, out_time=exit_t, state="done",
+                )
+                db.add(v)
+                db.flush()
+                if infrct:
+                    _make_alert(db, v, appt, hw_shift, entry_t + timedelta(minutes=3), "safety")
+            print(f"    [hw-{status[:8]:<8}] {plate:12s}")
+
+        # ─────────────────────────────────────────────────────────────────────
+        # RECENT HISTORICAL DATA (last 5 days — existing pattern)
+        # ─────────────────────────────────────────────────────────────────────
+        print("\n  Creating recent historical data (5 days)...")
+        recent_daily = [12, 10, 14, 11, 13]
+        terminals_cycle = [terminal_norte, terminal_solidos, terminal_liquidos,
+                           terminal_norte, terminal_solidos]
+        for day_offset in range(1, 6):
+            d = today - timedelta(days=day_offset)
+            sm, sa, sn = recent_shift_map[d]
             _generate_historical_day(
                 db, d, hist_trucks, drivers,
-                hist_terminals_cycle[day_offset - 1],
-                gate_entry, gate_out, sm, sa,
-                historical_appts_per_day[day_offset - 1],
-                f"HIST-D{day_offset}",
+                terminals_cycle[day_offset - 1],
+                gate_entry, gate_out, sm, sa, sn,
+                recent_daily[day_offset - 1], "HIST-R", counter,
             )
-            print(f"    Day -{day_offset} ({d}): {historical_appts_per_day[day_offset-1]} appointments")
+            print(f"    Day -{day_offset} ({d}): {recent_daily[day_offset-1]} appointments")
+
+        # ─────────────────────────────────────────────────────────────────────
+        # 12-MONTH BULK HISTORICAL DATA
+        # Monthly volume varies to simulate seasonality (higher summer/autumn)
+        # ─────────────────────────────────────────────────────────────────────
+        print("\n  Creating 12-month bulk historical data...")
+
+        # Volume multiplier per month (January=1 through December=12)
+        _MONTHLY_LOAD = {
+            1: 0.70,  # Jan — low (post-holidays)
+            2: 0.75,  # Feb
+            3: 0.85,  # Mar
+            4: 0.90,  # Apr
+            5: 0.95,  # May
+            6: 1.00,  # Jun
+            7: 1.10,  # Jul — peak summer
+            8: 1.15,  # Aug — peak summer
+            9: 1.10,  # Sep — autumn harvest
+            10: 1.05, # Oct
+            11: 0.85, # Nov
+            12: 0.75, # Dec — holidays
+        }
+
+        BASE_DAILY = 20       # base appointments on a weekday
+        WEEKEND_FACTOR = 0.4  # weekends have ~40% of weekday load
+
+        total_hist = 0
+        prev_month = None
+        all_terminals = [terminal_norte, terminal_solidos, terminal_liquidos]
+
+        sorted_hist_days = sorted(hist_shift_map.keys())
+        for d in sorted_hist_days:
+            month_load = _MONTHLY_LOAD.get(d.month, 1.0)
+            is_weekend = d.weekday() >= 5
+            load = month_load * (WEEKEND_FACTOR if is_weekend else 1.0)
+            num_appts = max(1, round(BASE_DAILY * load + random.randint(-2, 2)))
+
+            sm, sa, sn = hist_shift_map[d]
+            terminal = all_terminals[d.toordinal() % len(all_terminals)]
+            _generate_historical_day(
+                db, d, hist_trucks, drivers,
+                terminal, gate_entry, gate_out, sm, sa, sn,
+                num_appts, "HIST", counter,
+            )
+            total_hist += num_appts
+
+            if d.month != prev_month:
+                print(f"    Month {d.year}-{d.month:02d}: generating...")
+                prev_month = d.month
+
+        print(f"    Total historical appointments: {total_hist}")
 
         # ── Commit ────────────────────────────────────────────────────────────
-        print("\n  Saving to database...")
+        print("\n  Saving to database (this may take a moment)...")
         db.commit()
 
         # ── Summary ───────────────────────────────────────────────────────────
-        total_hist = sum(historical_appts_per_day)
         print("\n" + "=" * 70)
         print("  DATABASE INITIALIZED — PEI 2025 PORTO DE AVEIRO DEMO")
         print("=" * 70)
@@ -670,39 +846,43 @@ def init_demo_data(db: Session):
 │                        LOGIN CREDENTIALS                             │
 ├─────────────────────────────────────────────────────────────────────┤
 │  WEB PORTAL:                                                         │
-│    worker@porto.pt            │ password123  │ Operator              │
-│    manager@example.pt         │ password123  │ Manager               │
-│    teresa.lopes@portodeaveiro.pt │ password123 │ Manager             │
+│    worker@porto.pt               │ password123  │ Operator           │
+│    manager@example.pt            │ password123  │ Manager            │
+│    teresa.lopes@portodeaveiro.pt │ password123  │ Manager            │
 ├─────────────────────────────────────────────────────────────────────┤
 │  MOBILE APP (Drivers):                                               │
-│    PT12345678  Oscar Almeida      │ driver123                       │
-│    PT23456789  Sofia Rodrigues    │ driver123                       │
-│    ES87654321  Carlos Garcia      │ driver123                       │
-│    DE11223344  Hans Mueller       │ driver123                       │
-│    FR99887766  Pierre Dubois      │ driver123                       │
+│    PT12345678  Oscar Almeida     │ driver123                        │
+│    PT23456789  Sofia Rodrigues   │ driver123                        │
+│    ES87654321  Carlos Garcia     │ driver123                        │
+│    DE11223344  Hans Mueller      │ driver123                        │
+│    FR99887766  Pierre Dubois     │ driver123                        │
 └─────────────────────────────────────────────────────────────────────┘
 """)
 
         print(f"""
 ┌─────────────────────────────────────────────────────────────────────┐
-│  VIDEO1 → Gate 1:  {len(VIDEO1_PLATES)} plates  (07:30 · 09:00 · 11:30 · 14:30 · 16:00 · 22:15) │
-│  VIDEO2 → Gate 2:  {len(VIDEO2_PLATES)} plates  (08:00 · 15:30 · 18:00 · 22:45)              │
-│  Bonus: {len(bonus_configs)} appts across Morning/Afternoon/Night + {len(peak_configs)} peak-hour │
-│  Historical appointments (5 days):  {total_hist}                       │
-│  Companies: {len(COMPANIES)} │ Drivers: {len(DRIVERS)} │ Trucks: {len(all_trucks_list)} (demo+hist)              │
+│  TODAY'S LIVE STATE:                                                 │
+│    87AX60     → in_transit  (only in_transit truck)                 │
+│    92BLN3     → in_process  (unloading)                             │
+│    82BTN5     → in_process  (unloading)                             │
+│    68BSH8     → scheduled   (+1.5h)                                 │
+│    PEI2025    → scheduled   (+2.0h)                                 │
+│    LN67OIZGB  → scheduled   (+3.0h)                                 │
+│    SLJP1523   → scheduled   (+4.0h)                                 │
+│    GGAB425    → scheduled   (+2.5h)                                 │
+│    321BI13    → completed   (with safety infraction)                │
+│    CA93896    → completed   (highway gate)                          │
+│    LN67OIZGB  → canceled    (earlier booking, same plate)           │
 ├─────────────────────────────────────────────────────────────────────┤
-│  Status computed dynamically — always valid for any run date/time    │
-├─────────────────────────────────────────────────────────────────────┤
-│  TERMINALS (Porto de Aveiro real coordinates):                       │
-│    Terminal Norte           (40.6520N, 8.7430W) — general cargo     │
-│    Terminal Granéis Sólidos (40.6446N, 8.7490W) — bulk solids      │
-│    Terminal Granéis Líquidos (40.6360N, 8.7520W) — HAZMAT liquid   │
+│  HISTORY: 12 months · ~{total_hist} appointments · seasonal variation    │
+│  CO₂ trend data available for all 12 months                         │
+│  Delay profiles vary per company (SLA analytics realistic)           │
+│  ~8% highway infractions in history · 12% operational alerts         │
 └─────────────────────────────────────────────────────────────────────┘
 """)
 
     except Exception as e:
         print(f"\n  ERROR: {e}")
+        import traceback; traceback.print_exc()
         db.rollback()
         raise
-
-

--- a/src/V_APP/Data_Module/scripts/data_init_trial.py
+++ b/src/V_APP/Data_Module/scripts/data_init_trial.py
@@ -337,7 +337,7 @@ def init_trial_data(db: Session):
                 appointment_id=appt_c.id, shift_gate_id=shift_c.gate_id,
                 shift_type=shift_c.shift_type, shift_date=shift_c.date,
                 entry_time=entry_c, out_time=entry_c + timedelta(minutes=40),
-                state="completed",
+                state="done",
             ))
             db.flush()
 

--- a/src/V_APP/Data_Module/scripts/migrationDBv4.sql
+++ b/src/V_APP/Data_Module/scripts/migrationDBv4.sql
@@ -1,0 +1,136 @@
+-- ============================================================
+-- Migration v4 — State Machine Refactor
+-- Appointment: remove 'unloading' and 'delayed' from persisted enum.
+-- Visit: replace 'completed' with 'in_port' and 'done'.
+-- ============================================================
+-- Safe to re-run: all steps use IF NOT EXISTS / OR REPLACE / idempotent logic.
+-- Apply AFTER migrationDBv3.sql.
+-- ============================================================
+
+BEGIN;
+
+-- ============================================================
+-- 1. APPOINTMENT STATUS ENUM
+--    Remove 'unloading' and 'delayed' (were never written by app
+--    code after refactor; backfill any legacy rows before altering).
+-- ============================================================
+
+-- 1a. Backfill: any rows that were left with status='unloading' → 'in_process'
+UPDATE appointment SET status = 'in_process' WHERE status = 'unloading';
+
+-- 1b. Backfill: any rows with status='delayed' → 'in_transit'
+UPDATE appointment SET status = 'in_transit' WHERE status = 'delayed';
+
+-- 1c. Rename the current type, create a clean replacement, swap columns, drop old.
+ALTER TYPE appointment_status RENAME TO appointment_status_old;
+
+CREATE TYPE appointment_status AS ENUM (
+    'scheduled',
+    'in_transit',
+    'in_process',
+    'completed',
+    'canceled'
+);
+
+ALTER TABLE appointment
+    ALTER COLUMN status TYPE appointment_status
+    USING status::text::appointment_status;
+
+DROP TYPE appointment_status_old;
+
+
+-- ============================================================
+-- 2. DELIVERY STATUS ENUM (Visit)
+--    Replace 'completed' with 'in_port' and 'done'.
+--    'not_started' and 'unloading' are kept (same meaning).
+-- ============================================================
+
+-- 2a. Backfill: 'completed' visit rows → 'done'
+--     (old trigger wrote state='completed' when out_time was set)
+UPDATE visit SET state = 'done' WHERE state = 'completed';
+
+-- 2b. Backfill: ALL 'not_started' rows → 'in_port'.
+--     Visit only exists when a truck has entered the port, so 'not_started'
+--     was never a meaningful persisted state. Every Visit starts as 'in_port'.
+UPDATE visit SET state = 'in_port' WHERE state = 'not_started';
+
+-- 2c. Rename old type, create new one (without not_started), swap, drop.
+ALTER TYPE delivery_status RENAME TO delivery_status_old;
+
+CREATE TYPE delivery_status AS ENUM (
+    'in_port',
+    'unloading',
+    'done'
+);
+
+ALTER TABLE visit
+    ALTER COLUMN state TYPE delivery_status
+    USING state::text::delivery_status;
+
+DROP TYPE delivery_status_old;
+
+
+-- ============================================================
+-- 3. FIX Visit default: was 'unloading', must be 'not_started'
+-- ============================================================
+
+ALTER TABLE visit ALTER COLUMN state SET DEFAULT 'not_started';
+
+
+-- ============================================================
+-- 4. UPDATE TRIGGER FUNCTIONS (see triggers.sql for full bodies)
+--    Replace inline to keep migration self-contained.
+-- ============================================================
+
+-- 4a. Status-transition validator (removes 'unloading' rule)
+CREATE OR REPLACE FUNCTION fn_validate_status_transition()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF OLD.status IN ('completed', 'canceled') AND NEW.status != OLD.status THEN
+        RAISE EXCEPTION 'Cannot change appointment status from % to %', OLD.status, NEW.status;
+    END IF;
+    IF OLD.status = 'scheduled' AND NEW.status NOT IN ('scheduled', 'in_transit', 'canceled') THEN
+        RAISE EXCEPTION 'Invalid transition: scheduled → %', NEW.status;
+    END IF;
+    IF OLD.status = 'in_transit' AND NEW.status NOT IN ('in_transit', 'in_process', 'canceled') THEN
+        RAISE EXCEPTION 'Invalid transition: in_transit → %', NEW.status;
+    END IF;
+    IF OLD.status = 'in_process' AND NEW.status NOT IN ('in_process', 'completed', 'canceled') THEN
+        RAISE EXCEPTION 'Invalid transition: in_process → %', NEW.status;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 4b. Visit completion (no longer auto-completes appointment)
+CREATE OR REPLACE FUNCTION fn_check_visit_completion()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.state = 'done' AND OLD.state = 'unloading' THEN
+        IF NEW.out_time IS NULL THEN
+            NEW.out_time := NOW();
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 4c. Analytics helper (replaces fn_sync_delayed_appointments)
+CREATE OR REPLACE FUNCTION fn_count_delayed_appointments(tolerance_minutes INTEGER DEFAULT 15)
+RETURNS TABLE(delayed_count INTEGER, appointment_ids INTEGER[]) AS $$
+DECLARE
+    found_ids INTEGER[];
+BEGIN
+    SELECT ARRAY_AGG(id) INTO found_ids
+    FROM appointment
+    WHERE status = 'in_transit'
+      AND scheduled_start_time IS NOT NULL
+      AND scheduled_start_time + (tolerance_minutes || ' minutes')::INTERVAL < NOW();
+    RETURN QUERY SELECT
+        COALESCE(array_length(found_ids, 1), 0),
+        COALESCE(found_ids, ARRAY[]::INTEGER[]);
+END;
+$$ LANGUAGE plpgsql;
+
+
+COMMIT;

--- a/src/V_APP/Data_Module/scripts/migrationDBv4.sql
+++ b/src/V_APP/Data_Module/scripts/migrationDBv4.sql
@@ -78,59 +78,10 @@ ALTER TABLE visit ALTER COLUMN state SET DEFAULT 'not_started';
 
 
 -- ============================================================
--- 4. UPDATE TRIGGER FUNCTIONS (see triggers.sql for full bodies)
---    Replace inline to keep migration self-contained.
+-- 4. TRIGGER FUNCTIONS
+--    The updated function bodies live in triggers.sql (CREATE OR REPLACE,
+--    idempotent). Apply triggers.sql after this migration to keep them
+--    in sync. No inline copies here to avoid duplication.
 -- ============================================================
-
--- 4a. Status-transition validator (removes 'unloading' rule)
-CREATE OR REPLACE FUNCTION fn_validate_status_transition()
-RETURNS TRIGGER AS $$
-BEGIN
-    IF OLD.status IN ('completed', 'canceled') AND NEW.status != OLD.status THEN
-        RAISE EXCEPTION 'Cannot change appointment status from % to %', OLD.status, NEW.status;
-    END IF;
-    IF OLD.status = 'scheduled' AND NEW.status NOT IN ('scheduled', 'in_transit', 'canceled') THEN
-        RAISE EXCEPTION 'Invalid transition: scheduled → %', NEW.status;
-    END IF;
-    IF OLD.status = 'in_transit' AND NEW.status NOT IN ('in_transit', 'in_process', 'canceled') THEN
-        RAISE EXCEPTION 'Invalid transition: in_transit → %', NEW.status;
-    END IF;
-    IF OLD.status = 'in_process' AND NEW.status NOT IN ('in_process', 'completed', 'canceled') THEN
-        RAISE EXCEPTION 'Invalid transition: in_process → %', NEW.status;
-    END IF;
-    RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-
--- 4b. Visit completion (no longer auto-completes appointment)
-CREATE OR REPLACE FUNCTION fn_check_visit_completion()
-RETURNS TRIGGER AS $$
-BEGIN
-    IF NEW.state = 'done' AND OLD.state = 'unloading' THEN
-        IF NEW.out_time IS NULL THEN
-            NEW.out_time := NOW();
-        END IF;
-    END IF;
-    RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-
--- 4c. Analytics helper (replaces fn_sync_delayed_appointments)
-CREATE OR REPLACE FUNCTION fn_count_delayed_appointments(tolerance_minutes INTEGER DEFAULT 15)
-RETURNS TABLE(delayed_count INTEGER, appointment_ids INTEGER[]) AS $$
-DECLARE
-    found_ids INTEGER[];
-BEGIN
-    SELECT ARRAY_AGG(id) INTO found_ids
-    FROM appointment
-    WHERE status = 'in_transit'
-      AND scheduled_start_time IS NOT NULL
-      AND scheduled_start_time + (tolerance_minutes || ' minutes')::INTERVAL < NOW();
-    RETURN QUERY SELECT
-        COALESCE(array_length(found_ids, 1), 0),
-        COALESCE(found_ids, ARRAY[]::INTEGER[]);
-END;
-$$ LANGUAGE plpgsql;
-
 
 COMMIT;

--- a/src/V_APP/Data_Module/scripts/migrationDBv4.sql
+++ b/src/V_APP/Data_Module/scripts/migrationDBv4.sql
@@ -1,7 +1,8 @@
 -- ============================================================
--- Migration v4 — State Machine Refactor
+-- Migration v4 — State Machine Refactor + Infraction Review
 -- Appointment: remove 'unloading' and 'delayed' from persisted enum.
 -- Visit: replace 'completed' with 'in_port' and 'done'.
+-- Infraction review: reviewed_at, reviewed_by, review_note.
 -- ============================================================
 -- Safe to re-run: all steps use IF NOT EXISTS / OR REPLACE / idempotent logic.
 -- Apply AFTER migrationDBv3.sql.
@@ -131,6 +132,17 @@ BEGIN
         COALESCE(found_ids, ARRAY[]::INTEGER[]);
 END;
 $$ LANGUAGE plpgsql;
+
+
+-- ============================================================
+-- 5. INFRACTION REVIEW FIELDS
+--    Track manager acknowledgement of highway infractions.
+-- ============================================================
+
+ALTER TABLE appointment
+    ADD COLUMN IF NOT EXISTS reviewed_at  TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS reviewed_by  VARCHAR(50),
+    ADD COLUMN IF NOT EXISTS review_note  TEXT;
 
 
 COMMIT;

--- a/src/V_APP/Data_Module/scripts/migrationDBv5.sql
+++ b/src/V_APP/Data_Module/scripts/migrationDBv5.sql
@@ -1,0 +1,24 @@
+-- ============================================================
+-- Migration v5 — CSV Appointments + RGPD Driver Decoupling
+-- appointment.driver_license: NOT NULL → NULL
+-- Allows appointments to be imported via CSV without a driver;
+-- driver associates later via claim PIN (arrival_id + booking_reference).
+-- ============================================================
+-- Safe to re-run: idempotent (DO $$ ... EXCEPTION WHEN).
+-- Apply AFTER migrationDBv4.sql.
+-- ============================================================
+
+BEGIN;
+
+-- 1. Drop NOT NULL constraint from appointment.driver_license
+--    Wrapped in a DO block so re-runs are safe even if already nullable.
+DO $$
+BEGIN
+    ALTER TABLE appointment ALTER COLUMN driver_license DROP NOT NULL;
+EXCEPTION
+    WHEN others THEN
+        -- Already nullable — nothing to do.
+        NULL;
+END $$;
+
+COMMIT;

--- a/src/V_APP/Data_Module/scripts/triggers.sql
+++ b/src/V_APP/Data_Module/scripts/triggers.sql
@@ -234,11 +234,11 @@ CREATE TRIGGER trg_create_shift_alert_history
 
 
 -- ============================================================
--- 9. BOOKING CREATED_AT AUTO-SET
--- Sets created_at timestamp on booking creation if not provided
+-- 9. CREATED_AT AUTO-SET (booking / worker / driver)
+-- Single shared function; each table gets its own trigger.
 -- ============================================================
 
-CREATE OR REPLACE FUNCTION fn_set_booking_created_at()
+CREATE OR REPLACE FUNCTION fn_set_created_at()
 RETURNS TRIGGER AS $$
 BEGIN
     IF NEW.created_at IS NULL THEN
@@ -252,51 +252,19 @@ DROP TRIGGER IF EXISTS trg_booking_created_at ON booking;
 CREATE TRIGGER trg_booking_created_at
     BEFORE INSERT ON booking
     FOR EACH ROW
-    EXECUTE FUNCTION fn_set_booking_created_at();
-
-
--- ============================================================
--- 10. WORKER CREATED_AT AUTO-SET
--- Sets created_at timestamp on worker creation if not provided
--- ============================================================
-
-CREATE OR REPLACE FUNCTION fn_set_worker_created_at()
-RETURNS TRIGGER AS $$
-BEGIN
-    IF NEW.created_at IS NULL THEN
-        NEW.created_at := NOW();
-    END IF;
-    RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
+    EXECUTE FUNCTION fn_set_created_at();
 
 DROP TRIGGER IF EXISTS trg_worker_created_at ON worker;
 CREATE TRIGGER trg_worker_created_at
     BEFORE INSERT ON worker
     FOR EACH ROW
-    EXECUTE FUNCTION fn_set_worker_created_at();
-
-
--- ============================================================
--- 11. DRIVER CREATED_AT AUTO-SET
--- Sets created_at timestamp on driver creation if not provided
--- ============================================================
-
-CREATE OR REPLACE FUNCTION fn_set_driver_created_at()
-RETURNS TRIGGER AS $$
-BEGIN
-    IF NEW.created_at IS NULL THEN
-        NEW.created_at := NOW();
-    END IF;
-    RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
+    EXECUTE FUNCTION fn_set_created_at();
 
 DROP TRIGGER IF EXISTS trg_driver_created_at ON driver;
 CREATE TRIGGER trg_driver_created_at
     BEFORE INSERT ON driver
     FOR EACH ROW
-    EXECUTE FUNCTION fn_set_driver_created_at();
+    EXECUTE FUNCTION fn_set_created_at();
 
 
 -- ============================================================

--- a/src/V_APP/Data_Module/scripts/triggers.sql
+++ b/src/V_APP/Data_Module/scripts/triggers.sql
@@ -8,31 +8,27 @@
 -- ============================================================
 
 -- ============================================================
--- 1. SYNC STATUS TO DB (OPTIONAL - for reports/analytics)
--- Call periodically to persist computed 'delayed' status to DB
--- This is optional since computed_status handles real-time display
+-- 1. COUNT DELAYED APPOINTMENTS (read-only, for analytics)
+-- 'delayed' is never stored in the DB — it is computed dynamically
+-- in Python (Appointment.is_delayed property). This function only
+-- counts how many in_transit appointments are currently past their
+-- scheduled_start_time + 15 minutes tolerance.
 -- ============================================================
 
-CREATE OR REPLACE FUNCTION fn_sync_delayed_appointments()
-RETURNS TABLE(updated_count INTEGER, appointments_updated INTEGER[]) AS $$
+CREATE OR REPLACE FUNCTION fn_count_delayed_appointments(tolerance_minutes INTEGER DEFAULT 15)
+RETURNS TABLE(delayed_count INTEGER, appointment_ids INTEGER[]) AS $$
 DECLARE
-    affected_ids INTEGER[];
+    found_ids INTEGER[];
 BEGIN
-    -- Sync appointments that should be marked as delayed in DB
-    -- Uses 5 minute tolerance (matching DELAY_TOLERANCE_MINUTES in Python)
-    WITH updated AS (
-        UPDATE appointment
-        SET status = 'delayed'
-        WHERE status = 'in_transit'
-          AND scheduled_start_time IS NOT NULL
-          AND scheduled_start_time + INTERVAL '5 minutes' < NOW()
-        RETURNING id
-    )
-    SELECT ARRAY_AGG(id) INTO affected_ids FROM updated;
-    
-    RETURN QUERY SELECT 
-        COALESCE(array_length(affected_ids, 1), 0),
-        COALESCE(affected_ids, ARRAY[]::INTEGER[]);
+    SELECT ARRAY_AGG(id) INTO found_ids
+    FROM appointment
+    WHERE status = 'in_transit'
+      AND scheduled_start_time IS NOT NULL
+      AND scheduled_start_time + (tolerance_minutes || ' minutes')::INTERVAL < NOW();
+
+    RETURN QUERY SELECT
+        COALESCE(array_length(found_ids, 1), 0),
+        COALESCE(found_ids, ARRAY[]::INTEGER[]);
 END;
 $$ LANGUAGE plpgsql;
 
@@ -45,15 +41,23 @@ $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION fn_validate_status_transition()
 RETURNS TRIGGER AS $$
 BEGIN
-    -- Cannot revert from completed or canceled
+    -- Cannot revert from terminal states
     IF OLD.status IN ('completed', 'canceled') AND NEW.status != OLD.status THEN
-        RAISE EXCEPTION 'Cannot change status from % to %', OLD.status, NEW.status;
+        RAISE EXCEPTION 'Cannot change appointment status from % to %', OLD.status, NEW.status;
     END IF;
 
-    -- Valid transitions: in_process -> unloading -> completed
-    -- Cannot go back from unloading to in_transit or in_process
-    IF OLD.status = 'unloading' AND NEW.status NOT IN ('unloading', 'completed', 'canceled') THEN
-        RAISE EXCEPTION 'Cannot change status from unloading to %', NEW.status;
+    -- Valid forward transitions only:
+    --   scheduled  → in_transit | canceled
+    --   in_transit → in_process | canceled
+    --   in_process → completed  | canceled
+    IF OLD.status = 'scheduled' AND NEW.status NOT IN ('scheduled', 'in_transit', 'canceled') THEN
+        RAISE EXCEPTION 'Invalid transition: scheduled → %', NEW.status;
+    END IF;
+    IF OLD.status = 'in_transit' AND NEW.status NOT IN ('in_transit', 'in_process', 'canceled') THEN
+        RAISE EXCEPTION 'Invalid transition: in_transit → %', NEW.status;
+    END IF;
+    IF OLD.status = 'in_process' AND NEW.status NOT IN ('in_process', 'completed', 'canceled') THEN
+        RAISE EXCEPTION 'Invalid transition: in_process → %', NEW.status;
     END IF;
 
     RETURN NEW;
@@ -75,16 +79,14 @@ CREATE TRIGGER trg_validate_status_transition
 CREATE OR REPLACE FUNCTION fn_check_visit_completion()
 RETURNS TRIGGER AS $$
 BEGIN
-    -- If out_time is being set and state is still 'unloading', mark as completed
-    IF NEW.out_time IS NOT NULL 
-       AND OLD.out_time IS NULL 
-       AND NEW.state = 'unloading' THEN
-        NEW.state := 'completed';
-        
-        -- Also update appointment status to completed
-        UPDATE appointment 
-        SET status = 'completed'
-        WHERE id = NEW.appointment_id;
+    -- When the driver marks unloading as done, transition visit state to 'done'.
+    -- The appointment itself is NOT auto-completed here — the driver must explicitly
+    -- confirm departure via the app (PATCH /appointments/{id}/status → completed).
+    IF NEW.state = 'done' AND OLD.state = 'unloading' THEN
+        -- Record out_time if not already set
+        IF NEW.out_time IS NULL THEN
+            NEW.out_time := NOW();
+        END IF;
     END IF;
     RETURN NEW;
 END;
@@ -300,23 +302,28 @@ CREATE TRIGGER trg_driver_created_at
 -- ============================================================
 -- USAGE NOTES:
 -- ============================================================
--- 
--- DELAYED STATUS:
--- The 'delayed' status is now computed dynamically in Python using
--- the Appointment.computed_status property. This provides real-time
--- status without relying on cron jobs or triggers.
 --
--- For analytics/reporting, you can optionally call:
---   SELECT * FROM fn_sync_delayed_appointments();
--- This syncs the computed status to the DB for historical queries.
+-- APPOINTMENT STATUS FLOW (persisted enum values only):
+--   scheduled → in_transit → in_process → completed | canceled
+--
+-- VISIT STATE FLOW:
+--   not_started → in_port → unloading → done
+--   (driver drives to dock → inside port → unloading cargo → unloading done)
+--   After 'done', the driver explicitly marks the appointment as 'completed' via app.
+--
+-- DELAYED STATUS:
+-- 'delayed' is never stored. Computed in Python (Appointment.is_delayed) and
+-- surfaced as display_status='delayed' in API responses.
+-- For analytics counts: SELECT * FROM fn_count_delayed_appointments(15);
 --
 -- ARRIVAL ID:
--- Auto-generated as PRT-XXXX on appointment insert
+-- Auto-generated as PRT-XXXX on appointment insert.
 --
 -- VISIT COMPLETION:
--- Setting out_time on visit auto-completes both visit and appointment
+-- Transitioning visit state to 'done' auto-sets out_time.
+-- Appointment completion is explicit (driver confirms departure in app).
 --
 -- ALERTS:
--- Automatically linked to shift history when created with visit_id
+-- Automatically linked to shift history when created with visit_id.
 --
 -- ============================================================

--- a/src/V_APP/Data_Module/tests/integration/test_arrival_state_enums.py
+++ b/src/V_APP/Data_Module/tests/integration/test_arrival_state_enums.py
@@ -1,13 +1,16 @@
 """
 Tests for arrival state enumerations (BR-15, BR-16).
 
-BR-15 — chegadas_diarias.estado_entrega (appointment status) must be one of
-         a defined set of values.  Implemented as `appointment_status` PG enum:
-         {scheduled, in_transit, in_process, unloading, canceled, delayed, completed}.
+BR-15 — appointment status must be one of the defined persisted values.
+         Implemented as `appointment_status` PG enum:
+         {scheduled, in_transit, in_process, completed, canceled}
+         Sub-states (delayed, unloading, in_port) are computed, never stored.
 
-BR-16 — chegadas_diarias.estado_descarga (delivery/visit state) must be one of
-         a defined set of values.  Implemented as `delivery_status` PG enum:
-         {not_started, unloading, completed}.
+BR-16 — visit/delivery state must be one of the defined values.
+         Implemented as `delivery_status` PG enum:
+         {in_port, unloading, done}
+         'not_started' removed — Visit is only created on port entry, so initial
+         state is always 'in_port'.
 
 Test layers:
   1. Structural — sql_models.py declares the enum values; schemas.py mirrors them.
@@ -38,15 +41,21 @@ _SCHEMAS_PATH = (
 )
 
 # ---------------------------------------------------------------------------
-# Expected enum members
+# Expected enum members (post-v4 refactor)
 # ---------------------------------------------------------------------------
 
+# Persisted appointment states — 'delayed' and 'unloading' are computed sub-states only.
 _APPOINTMENT_STATUSES = {
-    "scheduled", "in_transit", "in_process",
-    "unloading", "canceled", "delayed", "completed",
+    "scheduled", "in_transit", "in_process", "completed", "canceled",
 }
 
-_DELIVERY_STATUSES = {"not_started", "unloading", "completed"}
+# Persisted visit/delivery states — 'not_started' and 'completed' removed.
+# Visit is only created on port entry, so initial state is always 'in_port'.
+_DELIVERY_STATUSES = {"in_port", "unloading", "done"}
+
+# Sub-states that must NOT appear as persisted enum values
+_APPOINTMENT_COMPUTED_SUBSTATES = {"unloading", "delayed"}
+_DELIVERY_REMOVED_VALUES = {"completed", "not_started"}
 
 
 # ---------------------------------------------------------------------------
@@ -54,11 +63,7 @@ _DELIVERY_STATUSES = {"not_started", "unloading", "completed"}
 # ---------------------------------------------------------------------------
 
 def test_appointment_status_enum_declared_in_sql_models():
-    """
-    sql_models.py must declare an appointment_status PG enum that contains
-    all BR-15 values: scheduled, in_transit, in_process, unloading,
-    canceled, delayed, completed.
-    """
+    """sql_models.py must declare appointment_status with all BR-15 persisted values."""
     src = _MODELS_PATH.read_text()
     assert "appointment_status" in src, (
         "appointment_status enum not declared in sql_models.py"
@@ -69,11 +74,22 @@ def test_appointment_status_enum_declared_in_sql_models():
         )
 
 
+def test_appointment_status_enum_excludes_computed_substates():
+    """'unloading' and 'delayed' must not be persisted enum values (computed only)."""
+    src = _MODELS_PATH.read_text()
+    # Find the SEnum declaration for appointment_status
+    start = src.find("appointment_status_enum = SEnum(")
+    end = src.find(")", start)
+    block = src[start:end]
+    for substate in _APPOINTMENT_COMPUTED_SUBSTATES:
+        assert f"'{substate}'" not in block and f'"{substate}"' not in block, (
+            f"'{substate}' must not be a persisted appointment_status value — "
+            "it is a computed sub-state (BR-15 refactor)"
+        )
+
+
 def test_delivery_status_enum_declared_in_sql_models():
-    """
-    sql_models.py must declare a delivery_status PG enum that contains
-    all BR-16 values: not_started, unloading, completed.
-    """
+    """sql_models.py must declare delivery_status with all BR-16 values."""
     src = _MODELS_PATH.read_text()
     assert "delivery_status" in src, (
         "delivery_status enum not declared in sql_models.py"
@@ -84,13 +100,33 @@ def test_delivery_status_enum_declared_in_sql_models():
         )
 
 
+def test_delivery_status_enum_excludes_old_completed():
+    """'completed' must not be a delivery_status value — replaced by 'done' (BR-16 refactor)."""
+    src = _MODELS_PATH.read_text()
+    start = src.find("delivery_status_enum = SEnum(")
+    end = src.find(")", start)
+    block = src[start:end]
+    assert "'completed'" not in block and '"completed"' not in block, (
+        "'completed' was removed from delivery_status enum — use 'done' instead (BR-16)"
+    )
+
+
+def test_delivery_status_enum_excludes_not_started():
+    """'not_started' must not be a delivery_status value.
+    Visit is only created on port entry — initial state is always 'in_port' (BR-16 refactor)."""
+    src = _MODELS_PATH.read_text()
+    start = src.find("delivery_status_enum = SEnum(")
+    end = src.find(")", start)
+    block = src[start:end]
+    assert "'not_started'" not in block and '"not_started"' not in block, (
+        "'not_started' was removed from delivery_status enum — "
+        "Visit initial state is 'in_port' (BR-16 refactor)"
+    )
+
+
 def test_appointment_status_enum_mirrored_in_schemas():
-    """
-    AppointmentStatusEnum in schemas.py must expose exactly the same set
-    of values as the PG enum, so API serialisation stays in sync.
-    """
+    """AppointmentStatusEnum in schemas.py must expose the persisted set only."""
     src = _SCHEMAS_PATH.read_text()
-    # Locate AppointmentStatusEnum class
     start = src.find("class AppointmentStatusEnum")
     end = src.find("\nclass ", start + 1)
     block = src[start:end] if end != -1 else src[start:]
@@ -99,13 +135,14 @@ def test_appointment_status_enum_mirrored_in_schemas():
         assert f'"{value}"' in block or f"'{value}'" in block, (
             f"AppointmentStatusEnum in schemas.py is missing '{value}' (BR-15)"
         )
+    for substate in _APPOINTMENT_COMPUTED_SUBSTATES:
+        assert f'"{substate}"' not in block and f"'{substate}'" not in block, (
+            f"AppointmentStatusEnum must not contain computed sub-state '{substate}'"
+        )
 
 
 def test_delivery_status_enum_mirrored_in_schemas():
-    """
-    DeliveryStatusEnum in schemas.py must expose the same set of values
-    as the PG delivery_status enum.
-    """
+    """DeliveryStatusEnum in schemas.py must expose the same set as the PG enum."""
     src = _SCHEMAS_PATH.read_text()
     start = src.find("class DeliveryStatusEnum")
     end = src.find("\nclass ", start + 1)
@@ -115,14 +152,14 @@ def test_delivery_status_enum_mirrored_in_schemas():
         assert f'"{value}"' in block or f"'{value}'" in block, (
             f"DeliveryStatusEnum in schemas.py is missing '{value}' (BR-16)"
         )
+    for removed in _DELIVERY_REMOVED_VALUES:
+        assert f'"{removed}"' not in block and f"'{removed}'" not in block, (
+            f"DeliveryStatusEnum must not contain removed value '{removed}' (BR-16 refactor)"
+        )
 
 
 def test_invalid_appointment_status_rejected_by_enum():
-    """
-    Domain validation: AppointmentStatusEnum must not accept values outside
-    the defined set.  This confirms that the Pydantic schema enforces the
-    enum at the API boundary (no running services required).
-    """
+    """AppointmentStatusEnum must not accept values outside the defined persisted set."""
     from application.schemas import AppointmentStatusEnum
 
     valid_members = {e.value for e in AppointmentStatusEnum}
@@ -131,16 +168,18 @@ def test_invalid_appointment_status_rejected_by_enum():
         f"expected {_APPOINTMENT_STATUSES} (BR-15)"
     )
 
-    # Pydantic enum rejects unknown values
     import pytest as _pytest
     with _pytest.raises((ValueError, KeyError)):
         AppointmentStatusEnum("UNKNOWN_STATUS")
 
+    # Computed sub-states must also be rejected as enum values
+    for substate in _APPOINTMENT_COMPUTED_SUBSTATES:
+        with _pytest.raises((ValueError, KeyError)):
+            AppointmentStatusEnum(substate)
+
 
 def test_invalid_delivery_status_rejected_by_enum():
-    """
-    DeliveryStatusEnum must not accept values outside the defined set.
-    """
+    """DeliveryStatusEnum must not accept values outside the defined set."""
     from application.schemas import DeliveryStatusEnum
 
     valid_members = {e.value for e in DeliveryStatusEnum}
@@ -152,6 +191,8 @@ def test_invalid_delivery_status_rejected_by_enum():
     import pytest as _pytest
     with _pytest.raises((ValueError, KeyError)):
         DeliveryStatusEnum("UNKNOWN_STATE")
+    with _pytest.raises((ValueError, KeyError)):
+        DeliveryStatusEnum("completed")
 
 
 # ---------------------------------------------------------------------------
@@ -160,11 +201,7 @@ def test_invalid_delivery_status_rejected_by_enum():
 
 @pytest.mark.integration
 def test_pg_rejects_invalid_appointment_status(pg_session):
-    """
-    Inserting a row with an invalid appointment_status value must raise
-    a DataError from PostgreSQL — the type constraint is enforced at the
-    DB level, not only in Python.
-    """
+    """Inserting a row with an invalid appointment_status value must raise from PostgreSQL."""
     from sqlalchemy import text
     from sqlalchemy.exc import DataError, ProgrammingError
 
@@ -177,10 +214,7 @@ def test_pg_rejects_invalid_appointment_status(pg_session):
 
 @pytest.mark.integration
 def test_pg_rejects_invalid_delivery_status(pg_session):
-    """
-    Inserting a row with an invalid delivery_status value must raise
-    a DataError from PostgreSQL.
-    """
+    """Inserting a row with an invalid delivery_status value must raise from PostgreSQL."""
     from sqlalchemy import text
     from sqlalchemy.exc import DataError, ProgrammingError
 
@@ -193,12 +227,7 @@ def test_pg_rejects_invalid_delivery_status(pg_session):
 
 @pytest.mark.integration
 def test_all_valid_appointment_statuses_accepted_by_orm():
-    """
-    SQLAlchemy ORM must accept all defined appointment_status values
-    without raising (connects to PG and verifies enum type membership).
-    The query intentionally returns zero rows — we only check no TypeError
-    is raised by the enum coercion.
-    """
+    """SQLAlchemy ORM must accept all defined appointment_status values without raising."""
     from infrastructure.persistence.sql_models import Appointment
     from infrastructure.persistence.postgres import SessionLocal
 

--- a/src/V_APP/Data_Module/tests/test_appointment_manager_view.py
+++ b/src/V_APP/Data_Module/tests/test_appointment_manager_view.py
@@ -1,0 +1,70 @@
+"""
+Test — AppointmentManagerView RGPD redaction (Pydantic v2).
+
+Checks:
+1. AppointmentManagerView accepts valid Appointment data including driver_license.
+2. After validation, driver_license is always None (redacted).
+3. After validation, driver is always None (redacted).
+4. Non-driver fields (truck_license_plate, status, arrival_id) are preserved.
+"""
+
+import pytest
+from datetime import datetime
+from application.schemas import AppointmentManagerView, AppointmentStatusEnum
+
+
+def _make_raw_appointment(**overrides):
+    base = {
+        "id": 1,
+        "arrival_id": "PRT-0001",
+        "booking_reference": "BK-2026-001",
+        "truck_license_plate": "AA-00-BB",
+        "terminal_id": 1,
+        "status": AppointmentStatusEnum.scheduled,
+        "highway_infraction": False,
+        "scheduled_start_time": datetime(2026, 5, 25, 8, 0),
+        # PII fields — must be redacted
+        "driver_license": "PT12345678",
+        "driver": {
+            "drivers_license": "PT12345678",
+            "name": "João Silva",
+            "active": True,
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.unit
+class TestAppointmentManagerViewRedaction:
+
+    def test_driver_license_is_redacted(self):
+        raw = _make_raw_appointment()
+        view = AppointmentManagerView.model_validate(raw)
+        assert view.driver_license is None, "driver_license must be None for manager view"
+
+    def test_driver_is_redacted(self):
+        raw = _make_raw_appointment()
+        view = AppointmentManagerView.model_validate(raw)
+        assert view.driver is None, "driver must be None for manager view"
+
+    def test_non_driver_fields_preserved(self):
+        raw = _make_raw_appointment()
+        view = AppointmentManagerView.model_validate(raw)
+        assert view.truck_license_plate == "AA-00-BB"
+        assert view.status == AppointmentStatusEnum.scheduled
+        assert view.arrival_id == "PRT-0001"
+        assert view.id == 1
+
+    def test_validates_without_driver_license(self):
+        raw = _make_raw_appointment(driver_license=None, driver=None)
+        view = AppointmentManagerView.model_validate(raw)
+        assert view.driver_license is None
+        assert view.driver is None
+
+    def test_json_output_excludes_driver_pii(self):
+        raw = _make_raw_appointment()
+        view = AppointmentManagerView.model_validate(raw)
+        output = view.model_dump()
+        assert output["driver_license"] is None
+        assert output["driver"] is None

--- a/src/V_APP/Data_Module/tests/test_integration.py
+++ b/src/V_APP/Data_Module/tests/test_integration.py
@@ -84,8 +84,8 @@ class TestArrivals:
         response = client.get("/arrivals/stats")
         assert response.status_code == 200
         data = response.json()
-        # API returns actual appointment statuses
-        assert "in_transit" in data or "completed" in data or "delayed" in data or "canceled" in data
+        # API returns persisted appointment statuses (delayed is computed, not stored)
+        assert "in_transit" in data or "completed" in data or "scheduled" in data or "canceled" in data
 
     def test_get_next_arrivals(self, client: httpx.Client):
         """Gets next arrivals for a gate"""
@@ -122,15 +122,26 @@ class TestArrivals:
         assert response.status_code in [200, 404]
 
     def test_update_arrival_status(self, client: httpx.Client):
-        """Updates appointment status"""
+        """Updates appointment status — 422 expected for removed enum values like 'delayed'."""
         response = client.patch(
             "/arrivals/1/status",
             json={
-                "status": "delayed",  # Must be valid appointment_status_enum
+                "status": "in_transit",  # valid persisted status
                 "notes": "Test update"
             }
         )
         assert response.status_code in [200, 404, 422]
+
+    def test_update_arrival_status_rejects_computed_substates(self, client: httpx.Client):
+        """'delayed' and 'unloading' are computed sub-states and must not be accepted as input."""
+        for substate in ("delayed", "unloading"):
+            response = client.patch(
+                "/arrivals/1/status",
+                json={"status": substate}
+            )
+            assert response.status_code == 422, (
+                f"API must reject computed sub-state '{substate}' as a status update (BR-15)"
+            )
 
     def test_process_arrival_decision(self, client: httpx.Client):
         """Processes decision for appointment"""

--- a/src/V_APP/Data_Module/tests/unit/test_infraction_guard.py
+++ b/src/V_APP/Data_Module/tests/unit/test_infraction_guard.py
@@ -1,0 +1,86 @@
+"""
+Tests for highway infraction guard (business rule: truck must be in transit to receive infraction).
+
+Rules enforced:
+- cmd_flag_highway_infraction raises ValueError if status not in {scheduled, in_transit}
+- Route returns 409 when ValueError is raised
+- Infraction is allowed for scheduled and in_transit appointments
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from application.use_cases.appointment_commands import (
+    cmd_flag_highway_infraction,
+    _INFRACTION_ALLOWED_STATUSES,
+)
+
+
+def _make_uow_factory(status: str):
+    """Return a uow_factory that produces a mock UoW for a given appointment status."""
+    aggregate = {
+        "id": 1,
+        "status": status,
+        "gate_in_id": None,
+    }
+    mock_uow = MagicMock()
+    mock_uow.__enter__ = MagicMock(return_value=mock_uow)
+    mock_uow.__exit__ = MagicMock(return_value=False)
+    mock_uow.appointment_state.get_for_update.return_value = aggregate
+    mock_uow.outbox.append = MagicMock()
+    mock_uow.commit = MagicMock()
+    return lambda: mock_uow
+
+
+@pytest.mark.unit
+class TestInfractionAllowedStatuses:
+    def test_allowed_statuses_set_contains_expected_values(self):
+        assert _INFRACTION_ALLOWED_STATUSES == {"in_transit"}
+
+    def test_infraction_allowed_for_in_transit(self):
+        result = cmd_flag_highway_infraction(_make_uow_factory("in_transit"), 1)
+        assert result is not None
+        assert result["highway_infraction"] is True
+
+
+@pytest.mark.unit
+class TestInfractionRejectedStatuses:
+    @pytest.mark.parametrize("status", ["scheduled", "in_process", "completed", "canceled"])
+    def test_infraction_rejected_when_truck_not_in_transit(self, status):
+        with pytest.raises(ValueError) as exc_info:
+            cmd_flag_highway_infraction(_make_uow_factory(status), 1)
+        assert status in str(exc_info.value)
+        assert "in transit" in str(exc_info.value).lower() or "transit" in str(exc_info.value).lower()
+
+    def test_error_message_is_descriptive(self):
+        with pytest.raises(ValueError) as exc_info:
+            cmd_flag_highway_infraction(_make_uow_factory("in_process"), 1)
+        msg = str(exc_info.value)
+        assert "in_process" in msg
+        assert "port" in msg.lower() or "transit" in msg.lower()
+
+
+@pytest.mark.unit
+class TestInfractionNotFound:
+    def test_returns_none_when_appointment_missing(self):
+        mock_uow = MagicMock()
+        mock_uow.__enter__ = MagicMock(return_value=mock_uow)
+        mock_uow.__exit__ = MagicMock(return_value=False)
+        mock_uow.appointment_state.get_for_update.return_value = None
+
+        result = cmd_flag_highway_infraction(lambda: mock_uow, 999)
+        assert result is None
+
+
+@pytest.mark.unit
+class TestInfractionRouteReturns409:
+    """Route must return 409 when cmd raises ValueError (truck inside port)."""
+
+    def test_arrivals_route_returns_409_for_in_process(self):
+        """Structural check: the route must catch ValueError and raise HTTPException 409."""
+        from pathlib import Path
+        src = (
+            Path(__file__).parent.parent.parent / "routes" / "arrivals.py"
+        ).read_text()
+        # Route must have try/except ValueError → 409
+        assert "409" in src, "arrivals.py must return 409 for infraction guard violation"
+        assert "ValueError" in src, "arrivals.py must catch ValueError from cmd_flag_highway_infraction"

--- a/src/V_APP/Data_Module/tests/unit/test_infraction_review.py
+++ b/src/V_APP/Data_Module/tests/unit/test_infraction_review.py
@@ -1,0 +1,154 @@
+"""
+Tests for infraction review logic (cmd_review_infraction) and route structure.
+
+Rules enforced:
+- Raises ValueError when appointment has no highway_infraction flag
+- Sets reviewed_at (UTC datetime), reviewed_by, review_note on success
+- review_note is None when omitted or empty string
+- Re-reviewing (idempotent) overwrites the previous record
+- Route source wires ValueError → 409 and missing appointment → 404
+- migrationDBv4.sql contains the review columns with IF NOT EXISTS guard
+"""
+
+import pytest
+from datetime import datetime
+from application.use_cases.appointment_commands import cmd_review_infraction
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _appt(has_infraction: bool = True, already_reviewed: bool = False) -> dict:
+    return {
+        "id": 1,
+        "truck_license_plate": "AA-00-BB",
+        "highway_infraction": has_infraction,
+        "reviewed_at": datetime(2026, 1, 1) if already_reviewed else None,
+        "reviewed_by": "MG001" if already_reviewed else None,
+        "review_note": "prior note" if already_reviewed else None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestReviewInfractionNoFlag:
+    def test_raises_value_error_when_no_infraction(self):
+        with pytest.raises(ValueError):
+            cmd_review_infraction(_appt(has_infraction=False), reviewed_by="MG001")
+
+    def test_error_message_mentions_appointment_id(self):
+        with pytest.raises(ValueError) as exc_info:
+            cmd_review_infraction(_appt(has_infraction=False), reviewed_by="MG001")
+        assert "1" in str(exc_info.value)
+
+    def test_error_message_mentions_infraction(self):
+        with pytest.raises(ValueError) as exc_info:
+            cmd_review_infraction(_appt(has_infraction=False), reviewed_by="MG001")
+        assert "infraction" in str(exc_info.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# Success path
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestReviewInfractionSuccess:
+    def test_sets_reviewed_by(self):
+        result = cmd_review_infraction(_appt(), reviewed_by="MG042")
+        assert result["reviewed_by"] == "MG042"
+
+    def test_sets_reviewed_at_as_datetime(self):
+        result = cmd_review_infraction(_appt(), reviewed_by="MG001")
+        assert isinstance(result["reviewed_at"], datetime)
+
+    def test_reviewed_at_has_no_tzinfo(self):
+        # Route stores as naive UTC (TIMESTAMP not TIMESTAMPTZ in ORM column)
+        result = cmd_review_infraction(_appt(), reviewed_by="MG001")
+        assert result["reviewed_at"].tzinfo is None
+
+    def test_stores_note_when_provided(self):
+        result = cmd_review_infraction(_appt(), reviewed_by="MG001", note="Warned carrier")
+        assert result["review_note"] == "Warned carrier"
+
+    def test_strips_whitespace_from_note(self):
+        result = cmd_review_infraction(_appt(), reviewed_by="MG001", note="  note  ")
+        assert result["review_note"] == "note"
+
+    def test_stores_none_when_note_omitted(self):
+        result = cmd_review_infraction(_appt(), reviewed_by="MG001")
+        assert result["review_note"] is None
+
+    def test_stores_none_when_note_is_empty_string(self):
+        result = cmd_review_infraction(_appt(), reviewed_by="MG001", note="")
+        assert result["review_note"] is None
+
+    def test_stores_none_when_note_is_only_whitespace(self):
+        result = cmd_review_infraction(_appt(), reviewed_by="MG001", note="   ")
+        assert result["review_note"] is None
+
+    def test_returns_updated_dict(self):
+        result = cmd_review_infraction(_appt(), reviewed_by="MG001", note="Test")
+        assert result["id"] == 1
+        assert result["reviewed_by"] == "MG001"
+        assert result["review_note"] == "Test"
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestReviewInfractionIdempotent:
+    def test_overwrites_reviewed_by(self):
+        appt = _appt(already_reviewed=True)
+        result = cmd_review_infraction(appt, reviewed_by="MG099", note="Second review")
+        assert result["reviewed_by"] == "MG099"
+
+    def test_overwrites_review_note(self):
+        appt = _appt(already_reviewed=True)
+        result = cmd_review_infraction(appt, reviewed_by="MG001", note="Updated note")
+        assert result["review_note"] == "Updated note"
+
+    def test_overwrites_reviewed_at_with_new_timestamp(self):
+        appt = _appt(already_reviewed=True)
+        old_ts = appt["reviewed_at"]
+        result = cmd_review_infraction(appt, reviewed_by="MG001")
+        assert result["reviewed_at"] != old_ts
+
+
+# ---------------------------------------------------------------------------
+# Route structural checks (source inspection, no heavy imports)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestReviewRouteStructure:
+    def _arrivals_src(self) -> str:
+        from pathlib import Path
+        return (Path(__file__).parent.parent.parent / "routes" / "arrivals.py").read_text()
+
+    def test_route_exposes_review_endpoint(self):
+        assert "review" in self._arrivals_src()
+
+    def test_route_returns_404_for_missing_appointment(self):
+        assert "404" in self._arrivals_src()
+
+    def test_route_returns_409_for_guard_violations(self):
+        # Both infraction guard (highway_infraction) and review guard use 409
+        assert self._arrivals_src().count("409") >= 2
+
+    def test_route_calls_cmd_review_infraction(self):
+        assert "cmd_review_infraction" in self._arrivals_src()
+
+    def test_migration_v4_contains_reviewed_at(self):
+        from pathlib import Path
+        sql = (
+            Path(__file__).parent.parent.parent / "scripts" / "migrationDBv4.sql"
+        ).read_text()
+        assert "reviewed_at" in sql
+        assert "reviewed_by" in sql
+        assert "review_note" in sql
+        assert "IF NOT EXISTS" in sql

--- a/src/V_APP/Data_Module/tests/unit/test_phase11_dead_code.py
+++ b/src/V_APP/Data_Module/tests/unit/test_phase11_dead_code.py
@@ -100,39 +100,15 @@ class TestDataInitDemoEnvConfig:
         src = _src("scripts/data_init_demo.py")
         assert "DEMO_VIDEO2_PLATES" in src
 
-    def test_max_arrivals_env_var(self):
+    def test_base_daily_controls_volume(self):
+        # MAX_ARRIVALS was replaced by BASE_DAILY + monthly load factors
         src = _src("scripts/data_init_demo.py")
-        assert "MAX_ARRIVALS" in src
+        assert "BASE_DAILY" in src
 
-    def test_plates_sliced_by_max_arrivals(self):
+    def test_monthly_load_factors_present(self):
         src = _src("scripts/data_init_demo.py")
-        assert "[:MAX_ARRIVALS]" in src
+        assert "_MONTHLY_LOAD" in src
 
-    def test_max_arrivals_env_overrides(self):
-        """MAX_ARRIVALS from env truncates both plate lists."""
-        import importlib
-        import sys
-        import os
-
-        # Inject env before import
-        os.environ["MAX_ARRIVALS"] = "2"
-        os.environ["DEMO_VIDEO1_PLATES"] = '["A","B","C","D"]'
-        os.environ["DEMO_VIDEO2_PLATES"] = '["X","Y","Z"]'
-
-        # Reload to pick up env changes
-        script_path = str(_BASE / "scripts")
-        if script_path not in sys.path:
-            sys.path.insert(0, script_path)
-
-        if "data_init_demo" in sys.modules:
-            del sys.modules["data_init_demo"]
-        try:
-            import data_init_demo as demo
-            assert len(demo.VIDEO1_PLATES) <= 2
-            assert len(demo.VIDEO2_PLATES) <= 2
-        finally:
-            del os.environ["MAX_ARRIVALS"]
-            del os.environ["DEMO_VIDEO1_PLATES"]
-            del os.environ["DEMO_VIDEO2_PLATES"]
-            if "data_init_demo" in sys.modules:
-                del sys.modules["data_init_demo"]
+    def test_company_delay_profiles_present(self):
+        src = _src("scripts/data_init_demo.py")
+        assert "_COMPANY_DELAY_PROFILES" in src

--- a/src/V_APP/api_gateway/src/clients/internal_api_client.py
+++ b/src/V_APP/api_gateway/src/clients/internal_api_client.py
@@ -151,3 +151,23 @@ async def delete(
     return await _request("DELETE", path, params=params, headers=headers, timeout=timeout)
 
 
+async def proxy_multipart(path: str, body: bytes, content_type: str, timeout: float = 30.0) -> Any:
+    """
+    Forward a raw multipart POST to the Data Module without re-parsing the body.
+    Used by bulk CSV upload endpoints (arrivals/bulk, workers/shifts/bulk).
+    """
+    url = _build_url(path)
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.post(url, content=body, headers={"content-type": content_type})
+    except httpx.RequestError as exc:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=f"Data Module unreachable: {exc}")
+    if response.status_code >= 400:
+        try:
+            detail = response.json().get("detail", response.text)
+        except Exception:
+            detail = response.text
+        raise HTTPException(status_code=response.status_code, detail=detail)
+    return response.json()
+
+

--- a/src/V_APP/api_gateway/src/routers/arrivals.py
+++ b/src/V_APP/api_gateway/src/routers/arrivals.py
@@ -422,22 +422,9 @@ async def bulk_import_arrivals(request: Request):
     Bulk-import appointments from CSV. Transparent proxy to POST /api/v1/arrivals/bulk.
     Forwards the raw multipart body without parsing it (no python-multipart needed here).
     """
-    from clients.internal_api_client import _build_url
     body = await request.body()
     content_type = request.headers.get("content-type", "multipart/form-data")
-    url = _build_url("/arrivals/bulk")
-    try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            response = await client.post(url, content=body, headers={"content-type": content_type})
-    except httpx.RequestError as exc:
-        raise HTTPException(status_code=502, detail=f"Data Module unreachable: {exc}")
-    if response.status_code >= 400:
-        try:
-            detail = response.json().get("detail", response.text)
-        except Exception:
-            detail = response.text
-        raise HTTPException(status_code=response.status_code, detail=detail)
-    return response.json()
+    return await internal_client.proxy_multipart("/arrivals/bulk", body, content_type)
 
 
 # -------------------------------

--- a/src/V_APP/api_gateway/src/routers/arrivals.py
+++ b/src/V_APP/api_gateway/src/routers/arrivals.py
@@ -1,7 +1,8 @@
 from typing import Annotated, Optional, Dict, Any
 from datetime import date
 
-from fastapi import APIRouter, Query, Path, Body, Request, Depends
+import httpx
+from fastapi import APIRouter, Query, Path, Body, Request, Depends, HTTPException
 from pydantic import BaseModel
 from loguru import logger
 
@@ -340,6 +341,30 @@ async def flag_highway_infraction(
 
 
 # -------------------------------
+# PATCH: /api/arrivals/{appointment_id}/review
+# Manager-only: Mark highway infraction as reviewed
+# -------------------------------
+class InfractionReviewRequest(BaseModel):
+    reviewed_by: str
+    note: Optional[str] = None
+
+
+@router.patch("/arrivals/{appointment_id}/review")
+async def review_infraction(
+    appointment_id: Annotated[int, Path(description="Appointment ID")],
+    body: Annotated[InfractionReviewRequest, Body()],
+):
+    """
+    Record manager review of a highway infraction.
+    Proxy to PATCH /api/v1/arrivals/{appointment_id}/review
+    """
+    return await internal_client.patch(
+        f"/arrivals/{appointment_id}/review",
+        json=body.model_dump(exclude_none=True),
+    )
+
+
+# -------------------------------
 # PATCH: /api/arrivals/{appointment_id}/status
 # -------------------------------
 class AppointmentStatusUpdate(BaseModel):
@@ -385,6 +410,34 @@ async def update_arrival_status(
             logger.warning(f"WS driver broadcast failed for status_changed: {e}")
 
     return result
+
+
+# -------------------------------
+# POST: /api/arrivals/bulk — CSV import (no driver, RGPD)
+# NOTE: Must be before /arrivals/{appointment_id}/visit (specific before dynamic)
+# -------------------------------
+@router.post("/arrivals/bulk", status_code=201)
+async def bulk_import_arrivals(request: Request):
+    """
+    Bulk-import appointments from CSV. Transparent proxy to POST /api/v1/arrivals/bulk.
+    Forwards the raw multipart body without parsing it (no python-multipart needed here).
+    """
+    from clients.internal_api_client import _build_url
+    body = await request.body()
+    content_type = request.headers.get("content-type", "multipart/form-data")
+    url = _build_url("/arrivals/bulk")
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(url, content=body, headers={"content-type": content_type})
+    except httpx.RequestError as exc:
+        raise HTTPException(status_code=502, detail=f"Data Module unreachable: {exc}")
+    if response.status_code >= 400:
+        try:
+            detail = response.json().get("detail", response.text)
+        except Exception:
+            detail = response.text
+        raise HTTPException(status_code=response.status_code, detail=detail)
+    return response.json()
 
 
 # -------------------------------

--- a/src/V_APP/api_gateway/src/routers/statistics.py
+++ b/src/V_APP/api_gateway/src/routers/statistics.py
@@ -194,3 +194,41 @@ async def operator_performance(
         "/statistics/operators/performance",
         params={"hours": hours}
     )
+
+
+# ==================== SUSTAINABILITY ====================
+
+@router.get("/statistics/sustainability/summary")
+async def sustainability_summary(
+    from_date: Annotated[Optional[str], Query(description="Start date YYYY-MM-DD")] = None,
+    to_date: Annotated[Optional[str], Query(description="End date YYYY-MM-DD")] = None,
+):
+    """Proxy to Data Module: CO₂ and waiting-time KPIs."""
+    params = {}
+    if from_date:
+        params["from_date"] = from_date
+    if to_date:
+        params["to_date"] = to_date
+    try:
+        result = await internal_client.get("/statistics/sustainability/summary", params=params)
+        return result if isinstance(result, dict) else {}
+    except Exception as e:
+        logger.warning("Failed to fetch sustainability summary: %s", e)
+        return {}
+
+
+@router.get("/statistics/sustainability/trend")
+async def sustainability_trend(
+    granularity: Annotated[str, Query(description="'day' | 'week' | 'month'")] = "month",
+    n_periods: Annotated[int, Query(ge=1, le=52, description="Number of past periods")] = 12,
+):
+    """Proxy to Data Module: CO₂ time-series trend."""
+    try:
+        result = await internal_client.get(
+            "/statistics/sustainability/trend",
+            params={"granularity": granularity, "n": n_periods},
+        )
+        return result if isinstance(result, list) else []
+    except Exception as e:
+        logger.warning("Failed to fetch sustainability trend: %s", e)
+        return []

--- a/src/V_APP/api_gateway/src/routers/workers.py
+++ b/src/V_APP/api_gateway/src/routers/workers.py
@@ -7,8 +7,9 @@ import os
 from datetime import datetime, timedelta, timezone
 from typing import Annotated, Optional, Dict, Any
 
+import httpx
 import jwt as _jwt
-from fastapi import APIRouter, Query, Path, Body, Depends
+from fastapi import APIRouter, HTTPException, Query, Path, Body, Depends, Request
 from pydantic import BaseModel
 
 from clients import internal_api_client as internal_client
@@ -76,6 +77,81 @@ async def list_shifts(
     if gate_id is not None:
         params["gate_id"] = gate_id
     return await internal_client.get("/workers/shifts", params=params)
+
+
+# ==================== SHIFT CRUD ====================
+
+class ShiftCreatePayload(BaseModel):
+    gate_id: int
+    shift_type: str
+    date: str
+    operator_num_worker: Optional[str] = None
+    manager_num_worker: Optional[str] = None
+
+
+class ShiftUpdatePayload(BaseModel):
+    operator_num_worker: Optional[str] = None
+    manager_num_worker: Optional[str] = None
+
+
+@router.post("/workers/shifts", status_code=201)
+async def create_shift(
+    _user: Annotated[TokenPayload, Depends(require_role("manager"))],
+    body: ShiftCreatePayload,
+):
+    return await internal_client.post("/workers/shifts", json=body.model_dump())
+
+
+@router.put("/workers/shifts/{gate_id}/{shift_type}/{shift_date}")
+async def update_shift(
+    _user: Annotated[TokenPayload, Depends(require_role("manager"))],
+    gate_id: Annotated[int, Path()],
+    shift_type: Annotated[str, Path()],
+    shift_date: Annotated[str, Path()],
+    body: ShiftUpdatePayload,
+):
+    return await internal_client.put(
+        f"/workers/shifts/{gate_id}/{shift_type}/{shift_date}",
+        json=body.model_dump(exclude_none=True),
+    )
+
+
+@router.delete("/workers/shifts/{gate_id}/{shift_type}/{shift_date}", status_code=204)
+async def delete_shift(
+    _user: Annotated[TokenPayload, Depends(require_role("manager"))],
+    gate_id: Annotated[int, Path()],
+    shift_type: Annotated[str, Path()],
+    shift_date: Annotated[str, Path()],
+):
+    return await internal_client.delete(
+        f"/workers/shifts/{gate_id}/{shift_type}/{shift_date}"
+    )
+
+
+@router.post("/workers/shifts/bulk", status_code=200)
+async def bulk_import_shifts(
+    _user: Annotated[TokenPayload, Depends(require_role("manager"))],
+    request: Request,
+):
+    """
+    Transparent proxy for multipart CSV upload. Forwards raw body without parsing.
+    """
+    from clients.internal_api_client import _build_url
+    body = await request.body()
+    content_type = request.headers.get("content-type", "multipart/form-data")
+    url = _build_url("/workers/shifts/bulk")
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(url, content=body, headers={"content-type": content_type})
+    except httpx.RequestError as exc:
+        raise HTTPException(status_code=502, detail=f"Data Module unreachable: {exc}")
+    if response.status_code >= 400:
+        try:
+            detail = response.json().get("detail", response.text)
+        except Exception:
+            detail = response.text
+        raise HTTPException(status_code=response.status_code, detail=detail)
+    return response.json()
 
 
 # ==================== OPERATOR ENDPOINTS ====================

--- a/src/V_APP/api_gateway/src/routers/workers.py
+++ b/src/V_APP/api_gateway/src/routers/workers.py
@@ -97,14 +97,13 @@ async def list_operators(
 
 @router.get("/workers/operators/me")
 async def get_my_operator_info(
-    num_worker: Annotated[str, Query(description="Operator num_worker")],
     _user: Annotated[TokenPayload, Depends(require_role("operator", "manager"))],
 ):
     """
     Get authenticated operator's own profile.
-    Proxy to GET /api/v1/workers/operators/me
+    Resolves identity from JWT sub (email) — no query param needed.
     """
-    return await internal_client.get("/workers/operators/me", params={"num_worker": num_worker})
+    return await internal_client.get("/workers/operators/me", params={"email": _user.sub})
 
 
 @router.get("/workers/operators/{num_worker}")
@@ -181,14 +180,13 @@ async def list_managers(
 
 @router.get("/workers/managers/me")
 async def get_my_manager_info(
-    num_worker: Annotated[str, Query(description="Manager num_worker")],
     _user: Annotated[TokenPayload, Depends(require_role("manager"))],
 ):
     """
     Get authenticated manager's own profile.
-    Proxy to GET /api/v1/workers/managers/me
+    Resolves identity from JWT sub (email) — no query param needed.
     """
-    return await internal_client.get("/workers/managers/me", params={"num_worker": num_worker})
+    return await internal_client.get("/workers/managers/me", params={"email": _user.sub})
 
 
 @router.get("/workers/managers/{num_worker}")

--- a/src/V_APP/api_gateway/src/routers/workers.py
+++ b/src/V_APP/api_gateway/src/routers/workers.py
@@ -7,9 +7,8 @@ import os
 from datetime import datetime, timedelta, timezone
 from typing import Annotated, Optional, Dict, Any
 
-import httpx
 import jwt as _jwt
-from fastapi import APIRouter, HTTPException, Query, Path, Body, Depends, Request
+from fastapi import APIRouter, Query, Path, Body, Depends, Request
 from pydantic import BaseModel
 
 from clients import internal_api_client as internal_client
@@ -133,25 +132,10 @@ async def bulk_import_shifts(
     _user: Annotated[TokenPayload, Depends(require_role("manager"))],
     request: Request,
 ):
-    """
-    Transparent proxy for multipart CSV upload. Forwards raw body without parsing.
-    """
-    from clients.internal_api_client import _build_url
+    """Transparent proxy for multipart CSV upload."""
     body = await request.body()
     content_type = request.headers.get("content-type", "multipart/form-data")
-    url = _build_url("/workers/shifts/bulk")
-    try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            response = await client.post(url, content=body, headers={"content-type": content_type})
-    except httpx.RequestError as exc:
-        raise HTTPException(status_code=502, detail=f"Data Module unreachable: {exc}")
-    if response.status_code >= 400:
-        try:
-            detail = response.json().get("detail", response.text)
-        except Exception:
-            detail = response.text
-        raise HTTPException(status_code=response.status_code, detail=detail)
-    return response.json()
+    return await internal_client.proxy_multipart("/workers/shifts/bulk", body, content_type)
 
 
 # ==================== OPERATOR ENDPOINTS ====================

--- a/src/V_APP/docker-compose.yml
+++ b/src/V_APP/docker-compose.yml
@@ -85,6 +85,7 @@ services:
     build:
       context: ..
       dockerfile: V_APP/Data_Module/Dockerfile
+    image: v_app-data-module
     container_name: dm_data_module
     restart: unless-stopped
     depends_on:
@@ -144,9 +145,7 @@ services:
 
   # Outbox Worker — projects outbox_events to MongoDB + Redis read models
   outbox-worker:
-    build:
-      context: ..
-      dockerfile: V_APP/Data_Module/Dockerfile
+    image: v_app-data-module
     container_name: dm_outbox_worker
     restart: unless-stopped
     entrypoint: ["python", "scripts/simple_outbox_worker.py"]
@@ -183,9 +182,7 @@ services:
 
   # Statistics Aggregator — computes hourly/daily Mongo rollups for dashboard queries
   statistics-aggregator:
-    build:
-      context: ..
-      dockerfile: V_APP/Data_Module/Dockerfile
+    image: v_app-data-module
     container_name: dm_statistics_aggregator
     restart: unless-stopped
     entrypoint: ["python", "scripts/statistics_aggregator.py"]

--- a/tests/cross_component/test_kafka_topic_contracts.py
+++ b/tests/cross_component/test_kafka_topic_contracts.py
@@ -1,0 +1,228 @@
+"""
+Cross-component contract tests: Kafka topic names and message structure.
+
+These are static (no running services) structural tests that verify the
+AI_APP and V_APP agree on the Kafka topic names and message field names
+used to communicate at runtime.
+
+If any of these fail, a topic-name mismatch will cause silent message loss
+in production (producers write to a topic no consumer reads).
+
+Run:
+    PYTHONPATH=src pytest tests/cross_component/test_kafka_topic_contracts.py -v
+"""
+
+import pathlib
+import sys
+
+# Paths
+ROOT = pathlib.Path(__file__).parent.parent.parent
+SRC = ROOT / "src"
+
+# Add shared src to path so we can import KafkaTopicFactory
+sys.path.insert(0, str(SRC))
+
+from shared.src.kafka_protocol import KafkaTopicFactory  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# 1. Topic naming consistency — verify format strings are stable
+# ---------------------------------------------------------------------------
+
+class TestKafkaTopicNamingContract:
+    """KafkaTopicFactory must produce deterministic, symmetric topic names."""
+
+    def test_truck_detected_topic_format(self):
+        assert KafkaTopicFactory.truck_detected(1) == KafkaTopicFactory.truck_detected(1)
+        assert KafkaTopicFactory.truck_detected(1) != KafkaTopicFactory.truck_detected(2)
+
+    def test_license_plate_results_topic_format(self):
+        assert KafkaTopicFactory.license_plate_results(1) == KafkaTopicFactory.license_plate_results(1)
+
+    def test_hazard_plate_results_topic_format(self):
+        assert KafkaTopicFactory.hazard_plate_results(1) == KafkaTopicFactory.hazard_plate_results(1)
+
+    def test_agent_decision_topic_format(self):
+        assert KafkaTopicFactory.agent_decision(1) == KafkaTopicFactory.agent_decision(1)
+
+    def test_operator_decision_topic_format(self):
+        assert KafkaTopicFactory.operator_decision(1) == KafkaTopicFactory.operator_decision(1)
+
+    def test_infraction_decision_topic_format(self):
+        assert KafkaTopicFactory.infraction_decision(1) == KafkaTopicFactory.infraction_decision(1)
+
+    def test_gate_id_is_part_of_topic_name(self):
+        """Gate-scoped topics must embed the gate_id so multiple gates don't collide."""
+        t1 = KafkaTopicFactory.truck_detected(1)
+        t2 = KafkaTopicFactory.truck_detected(2)
+        assert "1" in t1 or "1" in t1
+        assert t1 != t2, "Topics for different gates must be distinct"
+
+
+# ---------------------------------------------------------------------------
+# 2. AI_APP producer topics ↔ V_APP consumer topics (symmetric)
+# ---------------------------------------------------------------------------
+
+class TestAIAppVAppTopicSymmetry:
+    """
+    AI_APP gateway produces on topic X → V_APP gateway/consumer consumes on topic X.
+    Verify by reading source files and checking that the same KafkaTopicFactory
+    method names appear on both sides.
+    """
+
+    AI_GATEWAY_SRC = SRC / "AI_APP" / "gateway" / "src" / "ai_gateway.py"
+    V_GATEWAY_SRC = SRC / "V_APP" / "gateway" / "src" / "v_gateway.py"
+    V_CONSUMER_SRC = SRC / "V_APP" / "Data_Module" / "infrastructure" / "messaging" / "kafka_decision_consumer.py"
+
+    def _read(self, path: pathlib.Path) -> str:
+        return path.read_text()
+
+    def test_ai_gateway_file_exists(self):
+        assert self.AI_GATEWAY_SRC.exists(), f"AI gateway source not found: {self.AI_GATEWAY_SRC}"
+
+    def test_v_gateway_file_exists(self):
+        assert self.V_GATEWAY_SRC.exists(), f"V_APP gateway source not found: {self.V_GATEWAY_SRC}"
+
+    def test_v_consumer_file_exists(self):
+        assert self.V_CONSUMER_SRC.exists(), f"Kafka consumer not found: {self.V_CONSUMER_SRC}"
+
+    def test_ai_gateway_uses_shared_topic_factory(self):
+        """AI gateway must use KafkaTopicFactory — not hardcoded topic strings."""
+        src = self._read(self.AI_GATEWAY_SRC)
+        assert "KafkaTopicFactory" in src, (
+            "ai_gateway.py must use KafkaTopicFactory for topic names — "
+            "hardcoded strings break cross-component contracts."
+        )
+
+    def test_v_gateway_uses_shared_topic_factory(self):
+        src = self._read(self.V_GATEWAY_SRC)
+        assert "KafkaTopicFactory" in src, (
+            "v_gateway.py must use KafkaTopicFactory for topic names."
+        )
+
+    def test_v_consumer_uses_shared_topic_factory(self):
+        src = self._read(self.V_CONSUMER_SRC)
+        assert "KafkaTopicFactory" in src, (
+            "kafka_decision_consumer.py must use KafkaTopicFactory — "
+            "not hardcoded topic strings."
+        )
+
+    def test_agent_decision_topic_consumed_by_v_app(self):
+        """agent_decision topics produced by AI_APP must be consumed by V_APP."""
+        v_consumer = self._read(self.V_CONSUMER_SRC)
+        assert "agent_decision" in v_consumer, (
+            "V_APP kafka_decision_consumer must subscribe to agent_decision topics."
+        )
+
+    def test_infraction_decision_topic_consumed_by_v_app(self):
+        v_consumer = self._read(self.V_CONSUMER_SRC)
+        assert "infraction_decision" in v_consumer, (
+            "V_APP kafka_decision_consumer must subscribe to infraction_decision topics."
+        )
+
+    def test_v_gateway_relays_truck_detected(self):
+        """V_APP gateway must relay truck_detected topics from AI_APP to V broker."""
+        v_gateway = self._read(self.V_GATEWAY_SRC)
+        assert "truck_detected" in v_gateway, (
+            "v_gateway.py must relay truck_detected messages from AI_APP."
+        )
+
+    def test_v_gateway_relays_license_plate_results(self):
+        v_gateway = self._read(self.V_GATEWAY_SRC)
+        assert "license_plate_results" in v_gateway, (
+            "v_gateway.py must relay license_plate_results messages from AI_APP."
+        )
+
+    def test_v_gateway_relays_hazard_plate_results(self):
+        v_gateway = self._read(self.V_GATEWAY_SRC)
+        assert "hazard_plate_results" in v_gateway, (
+            "v_gateway.py must relay hazard_plate_results messages from AI_APP."
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. EventEnvelope contract — V_APP Data Module event schema
+# ---------------------------------------------------------------------------
+
+class TestEventEnvelopeContract:
+    """
+    EventEnvelope is the V_APP's standard for all domain events.
+    Verify its required fields are present and stable.
+    """
+
+    EVENTS_SRC = SRC / "V_APP" / "Data_Module" / "domain" / "events.py"
+
+    _REQUIRED_FIELDS = [
+        "event_id",
+        "correlation_id",
+        "causation_id",
+        "aggregate_type",
+        "aggregate_id",
+        "event_type",
+        "event_version",
+        "occurred_at",
+        "producer",
+        "partition_key",
+        "payload",
+    ]
+
+    def test_event_envelope_exists(self):
+        src = self.EVENTS_SRC.read_text()
+        assert "class EventEnvelope" in src, "EventEnvelope dataclass must exist in domain/events.py"
+
+    def test_event_envelope_is_frozen_dataclass(self):
+        src = self.EVENTS_SRC.read_text()
+        assert "frozen=True" in src or "@dataclass" in src, (
+            "EventEnvelope must be a frozen dataclass (immutable, hashable)."
+        )
+
+    def test_all_required_fields_present(self):
+        src = self.EVENTS_SRC.read_text()
+        start = src.find("class EventEnvelope")
+        block = src[start:start + 800]
+        for field in self._REQUIRED_FIELDS:
+            assert field in block, (
+                f"EventEnvelope is missing required field '{field}' — "
+                "this field is part of the cross-component event contract."
+            )
+
+    def test_new_event_id_uses_uuidv7(self):
+        """Events must use UUIDv7 for monotonic ordering."""
+        src = self.EVENTS_SRC.read_text()
+        assert "new_event_id" in src, "domain/events.py must export new_event_id()"
+        assert "uuid" in src.lower() or "UUID" in src, (
+            "new_event_id must generate UUID-based IDs."
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4. ContainerMovedHandler — V_APP must handle the AI_APP decision events
+# ---------------------------------------------------------------------------
+
+class TestContainerMovedHandlerContract:
+    """ContainerMovedHandler is the primary integration point between AI_APP and V_APP."""
+
+    HANDLER_SRC = SRC / "V_APP" / "Data_Module" / "application" / "use_cases" / "container_moved_handler.py"
+
+    def test_handler_exists(self):
+        assert self.HANDLER_SRC.exists(), "container_moved_handler.py must exist"
+
+    def test_handler_uses_uow(self):
+        src = self.HANDLER_SRC.read_text()
+        assert "uow" in src or "IUnitOfWork" in src, (
+            "ContainerMovedHandler must use UnitOfWork (Guardrail 2)."
+        )
+
+    def test_handler_uses_inbox_dedup(self):
+        src = self.HANDLER_SRC.read_text()
+        assert "inbox" in src.lower(), (
+            "ContainerMovedHandler must use inbox deduplication to prevent "
+            "duplicate Kafka message processing."
+        )
+
+    def test_handler_appends_to_outbox(self):
+        src = self.HANDLER_SRC.read_text()
+        assert "outbox" in src.lower(), (
+            "ContainerMovedHandler must append domain events to the outbox "
+            "(Guardrail 3 — Transactional Outbox)."
+        )


### PR DESCRIPTION
This pull request introduces significant improvements to the test orchestration script, clarifies appointment status logic in the Data Module, and tightens up status enum definitions. The changes enhance test reliability, reporting, and maintainability, while also ensuring appointment status handling is more accurate and consistent across the codebase.

**Test suite and orchestration improvements:**

* Refactored `run_tests.sh` to modularize test execution by section (shared, AI_APP, V_APP, Data Module, cross-component), added per-section pass/fail/skip summary, and introduced flags (`--no-datamodule`, `--no-cross`) for selective test runs. Improved output formatting and coverage report generation. [[1]](diffhunk://#diff-852f71b2f559b6a22ca607e43dc0c380f77224a2bb4341644f6bfda23e30f7e4L2-L24) [[2]](diffhunk://#diff-852f71b2f559b6a22ca607e43dc0c380f77224a2bb4341644f6bfda23e30f7e4L34) [[3]](diffhunk://#diff-852f71b2f559b6a22ca607e43dc0c380f77224a2bb4341644f6bfda23e30f7e4L44-R261)
* Added a comprehensive `.dockerignore` file to exclude virtual environments, test artifacts, and editor/OS-specific files from Docker builds, reducing image size and avoiding unnecessary files.

**Appointment status and query logic:**

* Refined appointment status logic in `arrival_queries.py`:  
  - The "delayed" filter now only applies to "scheduled" appointments past the delay threshold, not "in_transit" ones (which are now flagged with `is_delayed` instead).  
  - The "unloading" filter is now strictly a sub-state of "in_process" with an active unloading visit.  
  - The "in_transit" filter now includes both on-time and delayed, with the delay state marked via `is_delayed`.  
  - Adjusted count queries to ensure disjoint counts for "in_process" and "unloading" and accurate delayed/scheduled tallies. [[1]](diffhunk://#diff-23e73f43ff7f78761208972b442ab09ff690df6f6b17e50ef7bee6af2760bbe4L23-L52) [[2]](diffhunk://#diff-23e73f43ff7f78761208972b442ab09ff690df6f6b17e50ef7bee6af2760bbe4L62-L76) [[3]](diffhunk://#diff-23e73f43ff7f78761208972b442ab09ff690df6f6b17e50ef7bee6af2760bbe4L86-R76) [[4]](diffhunk://#diff-23e73f43ff7f78761208972b442ab09ff690df6f6b17e50ef7bee6af2760bbe4R378) [[5]](diffhunk://#diff-23e73f43ff7f78761208972b442ab09ff690df6f6b17e50ef7bee6af2760bbe4L426-R425)
* Updated manager statistics and dashboard queries to match the new delayed/on-time logic, using the correct delay cutoff and ensuring correct grouping of appointment statuses. [[1]](diffhunk://#diff-5f41c8e5c9e2c4965a20909a4882ae77ab4771fcd72bc20bcd079441f6319baaL96-R102) [[2]](diffhunk://#diff-5f41c8e5c9e2c4965a20909a4882ae77ab4771fcd72bc20bcd079441f6319baaL107-L120)

**Status enum and schema cleanup:**

* Removed deprecated statuses (`delayed`, `unloading`) from `AppointmentStatusEnum` and renamed values in `DeliveryStatusEnum` for clarity and alignment with business logic. [[1]](diffhunk://#diff-be97e6e0ed8c56279b5713bef3f43534121345498c90873902fc0f5e6a1d4f05L16-R18) [[2]](diffhunk://#diff-be97e6e0ed8c56279b5713bef3f43534121345498c90873902fc0f5e6a1d4f05L43-R44)

**Minor fixes and consistency:**

* Updated driver queries to only consider active appointments with statuses `"in_transit"` or `"in_process"`, removing references to deprecated statuses.
* Fixed operator dashboard stats to report the correct status fields.